### PR TITLE
feat: support batch size greater than 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .vscode
+test/

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -165,15 +165,15 @@ void Engine::build() {
     doesSupportDynamicBatch = true;
     spdlog::info("Model supports dynamic batch size");
   } else {
-    spdlog::info("Model only supports fixed batch size of {}", input0Batch);
+    spdlog::info("Model requires fixed batch size of {}", input0Batch);
     // If the model supports a fixed batch size, ensure that the maxBatchSize
     // and optBatchSize were set correctly.
     if (kOptBatchSize != input0Batch || kMaxBatchSize != input0Batch) {
       throw std::runtime_error(
-          "Error, model only supports a fixed batch size of " +
+          "Error, model requires a fixed batch size of " +
           std::to_string(input0Batch) +
           ". Must set Options.optimized_batch_size and Options.max_batch_size "
-          "to 1");
+          "to this value.");
     }
   }
 
@@ -195,18 +195,17 @@ void Engine::build() {
     int32_t inputW = inputDims.d[3];
 
     // Specify the optimization profile.
-    // TODO batch size fixed to 1.
     if (doesSupportDynamicBatch) {
       optProfile->setDimensions(inputName, OptProfileSelector::kMIN,
                                 Dims4(1, inputC, inputH, inputW));
     } else {
       optProfile->setDimensions(inputName, OptProfileSelector::kMIN,
-                                Dims4(1, inputC, inputH, inputW));
+                                Dims4(kOptBatchSize, inputC, inputH, inputW));
     }
     optProfile->setDimensions(inputName, OptProfileSelector::kOPT,
-                              Dims4(1, inputC, inputH, inputW));
+                              Dims4(kOptBatchSize, inputC, inputH, inputW));
     optProfile->setDimensions(inputName, OptProfileSelector::kMAX,
-                              Dims4(1, inputC, inputH, inputW));
+                              Dims4(kMaxBatchSize, inputC, inputH, inputW));
   }
   config->addOptimizationProfile(optProfile);
 
@@ -313,7 +312,7 @@ void Engine::load() {
     const auto tensorShape = mEngine->getTensorShape(tensorName);
     if (tensorType == TensorIOMode::kINPUT) {
       checkCudaErrorCode(cudaMallocAsync(&mBuffers[i],
-                                         tensorShape.d[1] * tensorShape.d[2] *
+                                         tensorShape.d[0] * tensorShape.d[1] * tensorShape.d[2] *
                                              tensorShape.d[3] * sizeof(float),
                                          stream));
 
@@ -334,7 +333,7 @@ void Engine::load() {
 
       mOutputLengths.push_back(outputLenFloat);
       checkCudaErrorCode(cudaMallocAsync(
-          &mBuffers[i], outputLenFloat * sizeof(float), stream));
+          &mBuffers[i], outputLenFloat * kMaxBatchSize * sizeof(float), stream));
     } else {
       throw std::runtime_error(
           "Error, IO Tensor is neither an input or output!");
@@ -353,9 +352,24 @@ rust::Vec<float> Engine::infer(const rust::Vec<float> &input) {
 
   const auto &dims = mInputDims[0];
 
+  // Check that the passed batch size can be handled.
+  const int32_t calculatedBatchSize = input.size() / (dims.d[0] * dims.d[1] * dims.d[2]);
+  if (calculatedBatchSize > kMaxBatchSize) {
+    throw std::runtime_error("Input exceeds max batch size: " + std::to_string(calculatedBatchSize) + " > " + std::to_string(kMaxBatchSize));
+  }
+
+  // If the network's batch size is fixed, the input batch dimension must match.
+  if (mInputBatchSize != -1 && calculatedBatchSize != mInputBatchSize) {
+    throw std::runtime_error("Input batch size does not match required fixed batch size: " + std::to_string(calculatedBatchSize) + " != " + std::to_string(kOptBatchSize));
+  }
+
+  // Check that vector has enough elements for full input.
+  if (input.size() % (dims.d[0] * dims.d[1] * dims.d[2]) != 0) {
+    throw std::runtime_error("Input vector incorrectly sized");
+  }
+   
   // Define the batch size.
-  // TODO: batch size fixed to 1 for now.
-  nvinfer1::Dims4 inputDims = {1, dims.d[0], dims.d[1], dims.d[2]};
+  nvinfer1::Dims4 inputDims = {calculatedBatchSize, dims.d[0], dims.d[1], dims.d[2]};
   mContext->setInputShape(mIOTensorNames[0].c_str(), inputDims);
 
   checkCudaErrorCode(
@@ -423,6 +437,8 @@ std::string Engine::serializeEngineOptions(const Options &options) {
   } else {
     canonicalName += "_int8";
   }
+
+  canonicalName += "_b" + std::to_string(options.optimized_batch_size) + "m" + std::to_string(options.max_batch_size);
 
   canonicalName += ".engine";
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -60,6 +60,7 @@ public:
 
   rust::Vec<uint32_t> getInputDims() const {
     rust::Vec<uint32_t> rv;
+    rv.push_back(mInputBatchSize);
     for (int i = 0; i < 3; ++i) {
       rv.push_back(mInputDims[0].d[i]);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod ffi {
         /// Where `device_name` is the `name` property of the CUDA device
         /// specified by `device_index`.
         ///
-        /// The engine file must match this name exactly to help ensure that only 
+        /// The engine file must match this name exactly to help ensure that only
         /// engines which have been built for the specific device are used.
         ///
         /// If an appropriate engine file is not found here or in `save_path`
@@ -87,9 +87,9 @@ pub mod ffi {
 
         /// Run inference on an input batch.
         ///
-        /// The input batch dimension is dependent on whether the engine has been built with fixed 
-        /// or dynamic input batch sizes. If fixed, the input batch dimensions 
-        /// must match the value returned by `get_input_dim`. Dynamic may accept any input batch size. 
+        /// The input batch dimension is dependent on whether the engine has been built with fixed
+        /// or dynamic input batch sizes. If fixed, the input batch dimensions
+        /// must match the value returned by `get_input_dim`. Dynamic may accept any input batch size.
         ///
         /// The input vector must be a flattened representation of shape
         /// `get_input_dim` with appropriate batch dimension. Likewise, the output dimension will

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,9 +45,10 @@ fn parse_file_to_float_vec(path: PathBuf) -> Vec<f32> {
 
 fn test_input_dim(engine: &UniquePtr<Engine>) {
     let input_dim = get_input_dim(&engine);
-    assert_eq!(input_dim[0], 3);
-    assert_eq!(input_dim[1], 640);
+    assert_eq!(input_dim[0], 1);
+    assert_eq!(input_dim[1], 3);
     assert_eq!(input_dim[2], 640);
+    assert_eq!(input_dim[3], 640);
 }
 
 fn test_output_dim(engine: &UniquePtr<Engine>) {
@@ -97,8 +98,8 @@ fn benchmark_inference(engine: &UniquePtr<Engine>) {
 /// Benchmark inference engine.
 fn main() {
     let options = Options {
-        model_name: "yolov8n".into(),
-        search_path: "tmp".into(),
+        model_name: "yolov8n_b1".into(),
+        search_path: "test".into(),
         save_path: "test".into(),
         device_index: 0,
         precision: Precision::FP16,
@@ -111,4 +112,41 @@ fn main() {
     test_output_dim(&engine);
     test_output_features(&engine);
     benchmark_inference(&engine);
+
+    let b2_options = Options {
+        model_name: "yolov8n_b2".into(),
+        optimized_batch_size: 2,
+        max_batch_size: 2,
+        ..options.clone()
+    };
+    let b2_engine = make_engine(&b2_options).unwrap();
+    benchmark_inference(&b2_engine);
+
+    let b4_options = Options {
+        model_name: "yolov8n_b4".into(),
+        optimized_batch_size: 4,
+        max_batch_size: 4,
+        ..options.clone()
+    };
+    let b4_engine = make_engine(&b4_options).unwrap();
+    benchmark_inference(&b4_engine);
+
+    let b8_options = Options {
+        model_name: "yolov8n_b8".into(),
+        optimized_batch_size: 8,
+        max_batch_size: 8,
+        ..options.clone()
+    };
+    let b8_engine = make_engine(&b8_options).unwrap();
+    benchmark_inference(&b8_engine);
+
+
+    let b16_options = Options {
+        model_name: "yolov8n_b16".into(),
+        optimized_batch_size: 16,
+        max_batch_size: 16,
+        ..options.clone()
+    };
+    let b16_engine = make_engine(&b16_options).unwrap();
+    benchmark_inference(&b16_engine);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@
 
 use approx::relative_eq;
 use cxx::UniquePtr;
-use libinfer::ffi::{get_input_dim, get_output_dim, make_engine, run_inference, Engine, Options, Precision};
+use libinfer::ffi::{
+    get_input_dim, get_output_dim, make_engine, run_inference, Engine, Options, Precision,
+};
 use std::fs::File;
 use std::io::Read;
 use std::io::{BufRead, BufReader};
@@ -67,19 +69,19 @@ fn test_output_features(engine: &UniquePtr<Engine>) {
             v.extend(
                 std::iter::repeat(&c)
                     .take(batch_size as usize)
-                    .flat_map(|v| v.iter().cloned())
+                    .flat_map(|v| v.iter().cloned()),
             );
         }
         v
     };
     let expected = {
-        let mut v = parse_file_to_float_vec("test/features.txt".into()); 
+        let mut v = parse_file_to_float_vec("test/features.txt".into());
         if batch_size > 0 {
             let c = v.clone();
             v.extend(
                 std::iter::repeat(&c)
                     .take(batch_size as usize)
-                    .flat_map(|v| v.iter().cloned())
+                    .flat_map(|v| v.iter().cloned()),
             );
         }
         v
@@ -135,13 +137,13 @@ fn main() {
         device_index: 0,
         precision: Precision::FP16,
         optimized_batch_size: 1,
-        max_batch_size: 1
+        max_batch_size: 1,
     };
     let b1_engine = make_engine(&b1_options).unwrap();
 
     test_input_dim(&b1_engine);
     test_output_dim(&b1_engine);
-    
+
     let b2_options = Options {
         model_name: "yolov8n_b2".into(),
         optimized_batch_size: 2,
@@ -166,7 +168,6 @@ fn main() {
     };
     let b8_engine = make_engine(&b8_options).unwrap();
 
-
     let b16_options = Options {
         model_name: "yolov8n_b16".into(),
         optimized_batch_size: 16,
@@ -183,5 +184,4 @@ fn main() {
     benchmark_inference(&b4_engine, n / 4);
     benchmark_inference(&b8_engine, n / 8);
     benchmark_inference(&b16_engine, n / 16);
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,14 +59,39 @@ fn test_output_dim(engine: &UniquePtr<Engine>) {
 }
 
 fn test_output_features(engine: &UniquePtr<Engine>) {
-    let input = read_binary_f32("test/input.bin".into());
+    let batch_size = get_input_dim(&engine)[0] - 1;
+    let input = {
+        let mut v = read_binary_f32("test/input.bin".into());
+        if batch_size > 0 {
+            let c = v.clone();
+            v.extend(
+                std::iter::repeat(&c)
+                    .take(batch_size as usize)
+                    .flat_map(|v| v.iter().cloned())
+            );
+        }
+        v
+    };
+    let expected = {
+        let mut v = parse_file_to_float_vec("test/features.txt".into()); 
+        if batch_size > 0 {
+            let c = v.clone();
+            v.extend(
+                std::iter::repeat(&c)
+                    .take(batch_size as usize)
+                    .flat_map(|v| v.iter().cloned())
+            );
+        }
+        v
+    };
+
     let actual = run_inference(&engine, &input).unwrap();
-    let expected = parse_file_to_float_vec("test/features.txt".into());
     let _ = zip(actual, expected).map(|(a, e)| relative_eq!(a, e, epsilon = 0.001));
 }
 
-fn benchmark_inference(engine: &UniquePtr<Engine>) {
+fn benchmark_inference(engine: &UniquePtr<Engine>, num_runs: u64) {
     let input_dim = get_input_dim(&engine);
+    let batch_size = input_dim[0];
     let input_len = input_dim.iter().fold(1, |acc, &e| acc * e) as usize;
     let input_data: Vec<f32> = repeat(0.0).take(input_len).collect();
 
@@ -77,8 +102,8 @@ fn benchmark_inference(engine: &UniquePtr<Engine>) {
     }
 
     // Measure.
-    println!("Testing inference...");
-    let latencies = (0..1 << 12)
+    println!("Beginning {num_runs} inference runs...");
+    let latencies = (0..num_runs)
         .map(|_| {
             let start = Instant::now();
             let _output = run_inference(&engine, &input_data).unwrap();
@@ -86,18 +111,24 @@ fn benchmark_inference(engine: &UniquePtr<Engine>) {
         })
         .collect::<Vec<Duration>>();
 
-    let average_latency =
-        latencies.iter().map(|t| t.as_secs_f32()).sum::<f32>() / latencies.len() as f32;
-    let average_framerate = 1.0 / average_latency;
+    let total_latency = latencies.iter().map(|t| t.as_secs_f32()).sum::<f32>();
+    let average_batch_latency = total_latency / latencies.len() as f32;
+    let average_batch_framerate = 1.0 / average_batch_latency;
+    let average_frame_latency = total_latency / (latencies.len() as f32 * batch_size as f32);
+    let average_frame_framerate = 1.0 / average_frame_latency;
 
-    println!("inference calls: {}", 2 << 15);
-    println!("avg. latency   : {}", average_latency);
-    println!("avg. fps       : {}", average_framerate);
+    println!("inference calls    : {}", num_runs);
+    println!("total latency      : {}", total_latency);
+    println!("avg. frame latency : {}", average_frame_latency);
+    println!("avg. frame fps     : {}", average_frame_framerate);
+    println!("avg. batch latency : {}", average_batch_latency);
+    println!("avg. batch fps     : {}", average_batch_framerate);
 }
 
 /// Benchmark inference engine.
 fn main() {
-    let options = Options {
+    let n = 2 << 15;
+    let b1_options = Options {
         model_name: "yolov8n_b1".into(),
         search_path: "test".into(),
         save_path: "test".into(),
@@ -106,47 +137,51 @@ fn main() {
         optimized_batch_size: 1,
         max_batch_size: 1
     };
-    let engine = make_engine(&options).unwrap();
+    let b1_engine = make_engine(&b1_options).unwrap();
 
-    test_input_dim(&engine);
-    test_output_dim(&engine);
-    test_output_features(&engine);
-    benchmark_inference(&engine);
-
+    test_input_dim(&b1_engine);
+    test_output_dim(&b1_engine);
+    
     let b2_options = Options {
         model_name: "yolov8n_b2".into(),
         optimized_batch_size: 2,
         max_batch_size: 2,
-        ..options.clone()
+        ..b1_options.clone()
     };
     let b2_engine = make_engine(&b2_options).unwrap();
-    benchmark_inference(&b2_engine);
 
     let b4_options = Options {
         model_name: "yolov8n_b4".into(),
         optimized_batch_size: 4,
         max_batch_size: 4,
-        ..options.clone()
+        ..b1_options.clone()
     };
     let b4_engine = make_engine(&b4_options).unwrap();
-    benchmark_inference(&b4_engine);
 
     let b8_options = Options {
         model_name: "yolov8n_b8".into(),
         optimized_batch_size: 8,
         max_batch_size: 8,
-        ..options.clone()
+        ..b1_options.clone()
     };
     let b8_engine = make_engine(&b8_options).unwrap();
-    benchmark_inference(&b8_engine);
 
 
     let b16_options = Options {
         model_name: "yolov8n_b16".into(),
         optimized_batch_size: 16,
         max_batch_size: 16,
-        ..options.clone()
+        ..b1_options.clone()
     };
     let b16_engine = make_engine(&b16_options).unwrap();
-    benchmark_inference(&b16_engine);
+
+    test_output_features(&b1_engine);
+    test_output_features(&b4_engine);
+
+    benchmark_inference(&b1_engine, n);
+    benchmark_inference(&b2_engine, n / 2);
+    benchmark_inference(&b4_engine, n / 4);
+    benchmark_inference(&b8_engine, n / 8);
+    benchmark_inference(&b16_engine, n / 16);
+
 }


### PR DESCRIPTION
Adds support for ONNX networks with fixed batch sizes of greater than 1. The inputs and outputs are flattened as previously, but now extended by the batch dimension.

Dynamic batch sizes are also supported, up to a max configured in `Options`.

On my RTX 4090, yolov8n produces the following results with the test program:

![Batch Size and Total Latency](https://github.com/saronic-technologies/libinfer/assets/7545238/3eb672d2-c470-4055-b35c-46405eea2449)
