### PR TITLE
fix: copy out whole batch, fix test

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -405,7 +405,7 @@ rust::Vec<float> Engine::infer(const rust::Vec<float> &input) {
     throw std::runtime_error("enqueue failed");
   }
 
-  const auto outputLen = mOutputLengths[0];
+  const auto outputLen = calculatedBatchSize * mOutputLengths[0];
   rust::Vec<float> output;
   resize(output, outputLen);
   checkCudaErrorCode(cudaMemcpyAsync(


### PR DESCRIPTION
Mistakenly was not copying out the whole batch size, only the first element. Updates the test program to check for this.