### PR TITLE
chore: fix input buffer allocation for dynamic batching

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -312,7 +312,7 @@ void Engine::load() {
     const auto tensorShape = mEngine->getTensorShape(tensorName);
     if (tensorType == TensorIOMode::kINPUT) {
       checkCudaErrorCode(cudaMallocAsync(&mBuffers[i],
-                                         tensorShape.d[0] * tensorShape.d[1] *
+                                         kMaxBatchSize * tensorShape.d[1] *
                                              tensorShape.d[2] *
                                              tensorShape.d[3] * sizeof(float),
                                          stream));

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,17 @@ fn main() {
     test_input_dim(&b1_engine);
     test_output_dim(&b1_engine);
 
+    let dynamic_options = Options {
+        model_name: "clip".into(),
+        search_path: "test".into(),
+        save_path: "test".into(),
+        device_index: 0,
+        precision: Precision::FP16,
+        optimized_batch_size: 32,
+        max_batch_size: 128,
+    };
+    let dynamic_engine = make_engine(&dynamic_options).unwrap();
+
     let b2_options = Options {
         model_name: "yolov8n_b2".into(),
         optimized_batch_size: 2,


### PR DESCRIPTION
`tensorShape.d[0] == -1` when dynamic batching is used. Instead, calculate the input buffer size based on the max batch size configured for the engine.