### PR TITLE
fix: log needs formattable, not path

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -235,8 +235,8 @@ void Engine::build() {
   }
 
   // Write the engine to disk (create output folder if necessary)
-  if (std::filesystem::create_directories(secondaryPath)) {
-    spdlog::info("Created output folder for engines at {}", secondaryPath);
+  if (std::filesystem::create_directories(std::filesystem::path(kSavePath))) {
+    spdlog::info("Created output folder for engines at {}", kSavePath);
   }
   std::ofstream outfile(mEnginePath, std::ofstream::binary);
   if (!outfile.is_open()) {


### PR DESCRIPTION
This builds and runs correctly now. Verified by running with `libinfer = { git = "ssh://git@github.com/saronic-technologies/libinfer.git", branch = "joe/mkdirs2" }` and non-existent engine output folder:

```
[2024-10-24 16:07:27.741] [libinfer] [info] Created output folder for engines at /home/saronic/.cache/engines
[2024-10-24 16:07:27.805] [libinfer] [info] Saved engine to /home/saronic/.cache/engines/yolov9e_custom_eo_1280_b2_pp_NVIDIAL4_fp16_b2m2.engine
```