### PR TITLE
chore: remove builder functionality

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1707689078,
-        "narHash": "sha256-UUGmRa84ZJHpGZ1WZEBEUOzaPOWG8LZ0yPg1pdDF/yM=",
+        "lastModified": 1731386116,
+        "narHash": "sha256-lKA770aUmjPHdTaJWnP3yQ9OI1TigenUqVC3wweqZuI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d39fb9aff0efee4a3d5f4a6d7c17701d38a1d8",
+        "rev": "689fed12a013f56d4c4d3f612489634267d86529",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
     jetpack-nixos.url = "github:anduril/jetpack-nixos";
   };
@@ -16,7 +16,7 @@
         pkgs = import nixpkgs { inherit system; };
         cudaPackages = if system == "aarch64-linux" then jetpack-nixos.legacyPackages.aarch64-linux.cudaPackages else pkgs.cudaPackages_11;
         l4t-cuda = jetpack-nixos.legacyPackages.aarch64-linux.l4t-cuda;
-        inherit (cudaPackages) cudatoolkit tensorrt cudnn cuda_cudart;
+        inherit (cudaPackages) cudatoolkit tensorrt_8_6 cudnn cuda_cudart;
 
         inputs = with pkgs; [
           bacon
@@ -28,7 +28,7 @@
           openssl
           pkg-config
           cudatoolkit
-          tensorrt
+          tensorrt_8_6
           rustc
           cargo
           rustfmt
@@ -42,7 +42,7 @@
           default = pkgs.mkShell {
             nativeBuildInputs = inputs;
             LIBCLANG_PATH = pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.libclang.lib}/lib/";
-            TENSORRT_LIBRARIES = "${tensorrt}/lib";
+            TENSORRT_LIBRARIES = "${tensorrt_8_6}/lib";
             CUDA_INCLUDE_DIRS = "${cudatoolkit}/include";
             CUDA_LIBRARIES = "${cudatoolkit}/lib";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
             TENSORRT_LIBRARIES = "${tensorrt_8_6}/lib";
             CUDA_INCLUDE_DIRS = "${cudatoolkit}/include";
             CUDA_LIBRARIES = "${cudatoolkit}/lib";
+            LD_LIBRARY_PATH = "${tensorrt_8_6}/lib";
           };
         };
       });

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -140,12 +140,6 @@ void Engine::load() {
     const auto tensorShape = mEngine->getTensorShape(tensorName);
     const auto tensorDataType = mEngine->getTensorDataType(tensorName);
     if (tensorType == TensorIOMode::kINPUT) {
-      checkCudaErrorCode(cudaMallocAsync(
-          &mBuffers[i],
-          mInputBatchSize * tensorShape.d[1] * tensorShape.d[2] *
-              tensorShape.d[3] * mInputDataTypeSize,
-          stream));
-
       // Store the input dims for later use
       mInputDims.emplace_back(tensorShape.d[1], tensorShape.d[2],
                               tensorShape.d[3]);
@@ -164,6 +158,13 @@ void Engine::load() {
         mInputDataTypeSize = 4;
         break;
       }
+
+      checkCudaErrorCode(cudaMallocAsync(
+          &mBuffers[i],
+          mInputBatchSize * tensorShape.d[1] * tensorShape.d[2] *
+              tensorShape.d[3] * mInputDataTypeSize,
+          stream));
+
     } else if (tensorType == TensorIOMode::kOUTPUT) {
       // The binding is an output
       uint32_t outputLenFloat = 1;
@@ -261,4 +262,3 @@ rust::Vec<float> Engine::infer(const rust::Vec<uint8_t> &input) {
 
   return output;
 }
-

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -13,9 +13,8 @@
 using namespace nvinfer1;
 
 // Implement our Rust friends.
-std::unique_ptr<Engine> make_engine(const Options &options) {
+std::unique_ptr<Engine> load_engine(const Options &options) {
   auto engine = std::make_unique<Engine>(options);
-  engine->build();
   engine->load();
   return engine;
 }
@@ -44,14 +43,8 @@ template <typename T> static void resize(rust::Vec<T> &v, size_t len) {
 }
 
 Engine::Engine(const Options &options)
-    : kModelName(options.model_name), kSearchPath(options.search_path),
-      kSavePath(options.save_path),
-      kCanonicalEngineName(serializeEngineOptions(options)),
-      kPrecision(static_cast<uint8_t>(options.precision)),
-      kDeviceIndex(options.device_index),
-      kOptBatchSize(options.optimized_batch_size),
-      kMaxBatchSize(options.max_batch_size),
-      kInputDataTypeSize(static_cast<uint8_t>(options.input_dtype))
+    : kEnginePath(options.path),
+      kDeviceIndex(options.device_index)
 {
   if (!spdlog::get("libinfer")) {
     spdlog::set_pattern("%+", spdlog::pattern_time_type::utc);
@@ -77,189 +70,6 @@ Engine::Engine(const Options &options)
   }
 }
 
-void Engine::build() {
-  const auto primaryPath = std::filesystem::path(kSearchPath) /
-                           std::filesystem::path(kCanonicalEngineName);
-  const auto secondaryPath = std::filesystem::path(kSavePath) /
-                             std::filesystem::path(kCanonicalEngineName);
-
-  // Check if engine exists at search path.
-  if (doesFileExist(primaryPath)) {
-    spdlog::info("Found engine {}", primaryPath.string());
-    mEnginePath = primaryPath;
-    return;
-  } else {
-    mEnginePath = secondaryPath;
-  }
-
-  // Check if engine exists at save path.
-  if (doesFileExist(mEnginePath)) {
-    spdlog::info("Found engine {}", secondaryPath.string());
-    return;
-  }
-
-  const auto onnxPath = std::filesystem::path(kSearchPath) /
-                        std::filesystem::path(kModelName + ".onnx");
-
-  if (!doesFileExist(onnxPath)) {
-    throw std::runtime_error("Could not find onnx model at path: " +
-                             onnxPath.string());
-  }
-
-  spdlog::info("Engine not found, generating. This could take a while...");
-
-  auto builder = std::unique_ptr<nvinfer1::IBuilder>(
-      nvinfer1::createInferBuilder(mLogger));
-  if (!builder) {
-    throw std::runtime_error("Could not create engine builder");
-  }
-
-  // Define an explicit batch size and then create the network (implicit batch
-  // size is deprecated). More info here:
-  // https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html#explicit-implicit-batch
-  auto explicitBatch = 1U << static_cast<uint32_t>(
-                           NetworkDefinitionCreationFlag::kEXPLICIT_BATCH);
-  auto network = std::unique_ptr<nvinfer1::INetworkDefinition>(
-      builder->createNetworkV2(explicitBatch));
-  if (!network) {
-    throw std::runtime_error("Could not create network definition");
-  }
-
-  auto parser = std::unique_ptr<nvonnxparser::IParser>(
-      nvonnxparser::createParser(*network, mLogger));
-  if (!parser) {
-    throw std::runtime_error("Could nto create onnx parser");
-  }
-
-  // We are going to first read the onnx file into memory, then pass that buffer
-  // to the parser. Had our onnx model file been encrypted, this approach would
-  // allow us to first decrypt the buffer.
-  std::ifstream file(onnxPath, std::ios::binary | std::ios::ate);
-  std::streamsize size = file.tellg();
-  file.seekg(0, std::ios::beg);
-
-  std::vector<char> buffer(size);
-  if (!file.read(buffer.data(), size)) {
-    throw std::runtime_error("Unable to read onnx file");
-  }
-
-  // Parse the buffer we read into memory.
-  auto parsed = parser->parse(buffer.data(), buffer.size());
-  if (!parsed) {
-    throw std::runtime_error("Could not parse onnx file");
-  }
-
-  // Ensure that all the inputs have the same batch size
-  const auto numInputs = network->getNbInputs();
-  if (numInputs < 1) {
-    throw std::runtime_error("Error, model needs at least 1 input!");
-  }
-  const auto input0Batch = network->getInput(0)->getDimensions().d[0];
-  for (int32_t i = 1; i < numInputs; ++i) {
-    if (network->getInput(i)->getDimensions().d[0] != input0Batch) {
-      throw std::runtime_error("Error, the model has multiple inputs, each "
-                               "with differing batch sizes!");
-    }
-  }
-
-  // Check to see if the model supports dynamic batch size or not
-  bool doesSupportDynamicBatch = false;
-  if (input0Batch == -1) {
-    doesSupportDynamicBatch = true;
-    spdlog::info("Model supports dynamic batch size");
-  } else {
-    spdlog::info("Model requires fixed batch size of {}", input0Batch);
-    // If the model supports a fixed batch size, ensure that the maxBatchSize
-    // and optBatchSize were set correctly.
-    if (kOptBatchSize != input0Batch || kMaxBatchSize != input0Batch) {
-      throw std::runtime_error(
-          "Error, model requires a fixed batch size of " +
-          std::to_string(input0Batch) +
-          ". Must set Options.optimized_batch_size and Options.max_batch_size "
-          "to this value.");
-    }
-  }
-
-  auto config =
-      std::unique_ptr<nvinfer1::IBuilderConfig>(builder->createBuilderConfig());
-  if (!config) {
-    throw std::runtime_error("Could not create builder config");
-  }
-
-  // Register a single optimization profile
-  IOptimizationProfile *optProfile = builder->createOptimizationProfile();
-  for (int32_t i = 0; i < numInputs; ++i) {
-    // Must specify dimensions for all the inputs the model expects.
-    const auto input = network->getInput(i);
-    const auto inputName = input->getName();
-    const auto inputDims = input->getDimensions();
-    int32_t inputC = inputDims.d[1];
-    int32_t inputH = inputDims.d[2];
-    int32_t inputW = inputDims.d[3];
-
-    // Specify the optimization profile.
-    if (doesSupportDynamicBatch) {
-      optProfile->setDimensions(inputName, OptProfileSelector::kMIN,
-                                Dims4(1, inputC, inputH, inputW));
-    } else {
-      optProfile->setDimensions(inputName, OptProfileSelector::kMIN,
-                                Dims4(kOptBatchSize, inputC, inputH, inputW));
-    }
-    optProfile->setDimensions(inputName, OptProfileSelector::kOPT,
-                              Dims4(kOptBatchSize, inputC, inputH, inputW));
-    optProfile->setDimensions(inputName, OptProfileSelector::kMAX,
-                              Dims4(kMaxBatchSize, inputC, inputH, inputW));
-  }
-  config->addOptimizationProfile(optProfile);
-
-  if (static_cast<Precision>(kPrecision) == Precision::FP16) {
-    if (!builder->platformHasFastFp16()) {
-      throw std::runtime_error("Error: GPU does not support FP16 precision");
-    }
-    config->setFlag(BuilderFlag::kFP16);
-  } else if (static_cast<Precision>(kPrecision) == Precision::INT8) {
-    throw std::runtime_error("INT8 is not yet supported");
-  }
-
-  // CUDA stream used for profiling by the builder.
-  cudaStream_t profileStream;
-  checkCudaErrorCode(cudaStreamCreate(&profileStream));
-  config->setProfileStream(profileStream);
-
-  // Build the engine.
-  // If this call fails, it is suggested to increase the logger verbosity to
-  // kVERBOSE and try rebuilding the engine. Doing so will provide you with more
-  // information on why exactly it is failing.
-  std::unique_ptr<IHostMemory> plan{
-      builder->buildSerializedNetwork(*network, *config)};
-  if (!plan) {
-    throw std::runtime_error("Could not create network serializer");
-  }
-
-  // Write the engine to disk (create output folder if necessary)
-  if (std::filesystem::create_directories(std::filesystem::path(kSavePath))) {
-    spdlog::info("Created output folder for engines at {}", kSavePath);
-  }
-  std::ofstream outfile(mEnginePath, std::ofstream::binary);
-  if (!outfile.is_open()) {
-    throw std::runtime_error("Could not open output file");
-  }
-
-  outfile.write(reinterpret_cast<const char *>(plan->data()), plan->size());
-  if (outfile.fail()) {
-    throw std::runtime_error("Could not write engine file to disk");
-  }
-
-  outfile.close();
-  if (outfile.fail()) {
-    throw std::runtime_error("Could not close engine file");
-  }
-
-  spdlog::info("Saved engine to {}", mEnginePath);
-
-  checkCudaErrorCode(cudaStreamDestroy(profileStream));
-}
-
 Engine::~Engine() {
   // Free the GPU memory
   for (auto &buffer : mBuffers) {
@@ -271,7 +81,7 @@ Engine::~Engine() {
 
 void Engine::load() {
   // Read the serialized model from disk
-  std::ifstream file(mEnginePath, std::ios::binary | std::ios::ate);
+  std::ifstream file(kEnginePath, std::ios::binary | std::ios::ate);
   if (!file.is_open()) {
     throw std::runtime_error("Could not open engine file");
   }
@@ -328,6 +138,7 @@ void Engine::load() {
   cudaStream_t stream;
   checkCudaErrorCode(cudaStreamCreate(&stream));
 
+
   // Allocate GPU memory for input and output buffers
   mOutputLengths.clear();
   for (int i = 0; i < mEngine->getNbIOTensors(); ++i) {
@@ -335,17 +146,33 @@ void Engine::load() {
     mIOTensorNames.emplace_back(tensorName);
     const auto tensorType = mEngine->getTensorIOMode(tensorName);
     const auto tensorShape = mEngine->getTensorShape(tensorName);
+    const auto tensorDataType = mEngine->getTensorDataType(tensorName);
     if (tensorType == TensorIOMode::kINPUT) {
         checkCudaErrorCode(
           cudaMallocAsync(&mBuffers[i],
-                          kMaxBatchSize * tensorShape.d[1] * tensorShape.d[2] *
-                              tensorShape.d[3] * kInputDataTypeSize,
+                          mInputBatchSize * tensorShape.d[1] * tensorShape.d[2] *
+                              tensorShape.d[3] * mInputDataTypeSize,
                           stream));
 
       // Store the input dims for later use
       mInputDims.emplace_back(tensorShape.d[1], tensorShape.d[2],
                               tensorShape.d[3]);
       mInputBatchSize = tensorShape.d[0];
+      switch (tensorDataType) {
+              case DataType::kFLOAT:
+                      mInputDataType = InputDataType::FP32;
+                        mInputDataTypeSize = 4;
+                break;
+case DataType::kUINT8:
+                      mInputDataType = InputDataType::UINT8;
+                        mInputDataTypeSize = 1;
+                break;
+default:
+                      mInputDataType = InputDataType::FP32;
+                        mInputDataTypeSize = 4;
+                break;
+
+      }
     } else if (tensorType == TensorIOMode::kOUTPUT) {
       // The binding is an output
       uint32_t outputLenFloat = 1;
@@ -359,7 +186,7 @@ void Engine::load() {
 
       mOutputLengths.push_back(outputLenFloat);
       checkCudaErrorCode(cudaMallocAsync(
-          &mBuffers[i], outputLenFloat * kMaxBatchSize * sizeof(float),
+          &mBuffers[i], outputLenFloat * mInputBatchSize * sizeof(float),
           stream));
     } else {
       throw std::runtime_error(
@@ -381,11 +208,11 @@ rust::Vec<float> Engine::infer(const rust::Vec<uint8_t> &input) {
 
   // Check that the passed batch size can be handled.
   const int32_t calculatedBatchSize =
-      input.size() / (dims.d[0] * dims.d[1] * dims.d[2] * kInputDataTypeSize);
-  if (calculatedBatchSize > kMaxBatchSize) {
+      input.size() / (dims.d[0] * dims.d[1] * dims.d[2] * mInputDataTypeSize);
+  if (calculatedBatchSize > mInputBatchSize) {
     throw std::runtime_error(
         "Input exceeds max batch size: " + std::to_string(calculatedBatchSize) +
-        " > " + std::to_string(kMaxBatchSize));
+        " > " + std::to_string(mInputBatchSize));
   }
 
   // If the network's batch size is fixed, the input batch dimension must match.
@@ -393,7 +220,7 @@ rust::Vec<float> Engine::infer(const rust::Vec<uint8_t> &input) {
     throw std::runtime_error(
         "Input batch size does not match required fixed batch size: " +
         std::to_string(calculatedBatchSize) +
-        " != " + std::to_string(kOptBatchSize));
+        " != " + std::to_string(mInputBatchSize));
   }
 
   // Check that vector has enough elements for full input.
@@ -442,42 +269,6 @@ rust::Vec<float> Engine::infer(const rust::Vec<uint8_t> &input) {
   checkCudaErrorCode(cudaStreamDestroy(inferenceCudaStream));
 
   return output;
-}
-
-std::string Engine::serializeEngineOptions(const Options &options) {
-  auto canonicalName = std::string(options.model_name);
-
-  // Add the GPU device name to the file to ensure that the model is only used
-  // on devices with the exact same GPU.
-  std::vector<std::string> deviceNames;
-  getDeviceNames(deviceNames);
-
-  if (static_cast<size_t>(options.device_index) >= deviceNames.size()) {
-    throw std::runtime_error("Provided device index is out of range");
-  }
-
-  auto deviceName = deviceNames[options.device_index];
-  deviceName.erase(
-      std::remove_if(deviceName.begin(), deviceName.end(), ::isspace),
-      deviceName.end());
-
-  canonicalName += "_" + deviceName;
-
-  // Serialize the specified options into the filename.
-  if (options.precision == Precision::FP16) {
-    canonicalName += "_fp16";
-  } else if (options.precision == Precision::FP32) {
-    canonicalName += "_fp32";
-  } else {
-    canonicalName += "_int8";
-  }
-
-  canonicalName += "_b" + std::to_string(options.optimized_batch_size) + "m" +
-                   std::to_string(options.max_batch_size);
-
-  canonicalName += ".engine";
-
-  return canonicalName;
 }
 
 void Engine::getDeviceNames(std::vector<std::string> &deviceNames) {

--- a/src/engine.h
+++ b/src/engine.h
@@ -11,6 +11,7 @@
 #include "rust/cxx.h"
 
 struct Options;
+enum class InputDataType : uint8_t;
 
 class Logger : public nvinfer1::ILogger {
 public:
@@ -66,9 +67,6 @@ public:
   Engine(const Options &options);
   ~Engine();
 
-  // Build the network.
-  void build();
-
   // Load and prepare the network for inference.
   void load();
 
@@ -94,6 +92,10 @@ public:
 
   uint32_t get_output_len() const { return mOutputLengths[0]; }
 
+  InputDataType get_input_data_type() const {
+      return mInputDataType;
+  }
+
 private:
   // Converts the engine options into a string.
   std::string serializeEngineOptions(const Options &options);
@@ -107,6 +109,8 @@ private:
   std::vector<nvinfer1::Dims> mOutputDims;
   std::vector<std::string> mIOTensorNames;
   int32_t mInputBatchSize;
+  InputDataType mInputDataType;
+  uint8_t mInputDataTypeSize;
 
   // Must keep IRuntime around for inference, see:
   // https://forums.developer.nvidia.com/t/is-it-safe-to-deallocate-nvinfer1-iruntime-after-creating-an-nvinfer1-icudaengine-but-before-running-inference-with-said-icudaengine/255381/2?u=cyruspk4w6
@@ -118,16 +122,9 @@ private:
   std::string mEnginePath;
 
   // Option values.
-  const std::string kModelName;
-  const std::string kSearchPath;
-  const std::string kSavePath;
-  const std::string kCanonicalEngineName;
-  const uint8_t kPrecision;
+  const std::string kEnginePath;
   const uint32_t kDeviceIndex;
-  const int32_t kOptBatchSize;
-  const int32_t kMaxBatchSize;
-  const uint8_t kInputDataTypeSize;
 };
 
 // Rust friends.
-std::unique_ptr<Engine> make_engine(const Options &options);
+std::unique_ptr<Engine> load_engine(const Options &options);

--- a/src/engine.h
+++ b/src/engine.h
@@ -92,16 +92,9 @@ public:
 
   uint32_t get_output_len() const { return mOutputLengths[0]; }
 
-  InputDataType get_input_data_type() const {
-      return mInputDataType;
-  }
+  InputDataType get_input_data_type() const { return mInputDataType; }
 
 private:
-  // Converts the engine options into a string.
-  std::string serializeEngineOptions(const Options &options);
-
-  void getDeviceNames(std::vector<std::string> &deviceNames);
-
   // Holds pointers to the input and output GPU buffers
   std::vector<void *> mBuffers;
   std::vector<uint32_t> mOutputLengths{};
@@ -119,9 +112,7 @@ private:
   std::unique_ptr<nvinfer1::IExecutionContext> mContext = nullptr;
   Logger mLogger;
 
-  std::string mEnginePath;
-
-  // Option values.
+  // Options values.
   const std::string kEnginePath;
   const uint32_t kDeviceIndex;
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod ffi {
         /// This is equivalent to multiplying the elements of `get_output_dim`.
         fn get_output_len(self: &Engine) -> u32;
 
+        /// Returns the input data type in use by this engine.
         fn get_input_data_type(self: &Engine) -> InputDataType;
 
         /// Run inference on an input batch.
@@ -58,8 +59,8 @@ pub mod ffi {
 }
 
 pub use crate::ffi::Engine;
-pub use crate::ffi::Options;
 pub use crate::ffi::InputDataType;
+pub use crate::ffi::Options;
 
 use cxx::{Exception, UniquePtr};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     };
     let mut b1_engine = Engine::new(&b1_options).unwrap();
 
-//    println!("Input data type: {:?}", b1_engine.get_input_data_type());
+    println!("Input data type: {:?}", b1_engine.get_input_data_type());
 
     test_input_dim(&b1_engine);
     test_output_dim(&b1_engine);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use approx::assert_relative_eq;
 use cxx::UniquePtr;
-use libinfer::{Engine, Options, Precision, InputDataType};
+use libinfer::{Engine, Options, InputDataType};
 use std::{
     fs::File,
     io::{BufRead, BufReader, Read},
@@ -135,58 +135,46 @@ fn benchmark_inference(engine: &mut UniquePtr<Engine>, num_runs: u64) {
 fn main() {
     let n = 2 << 15;
     let b1_options = Options {
-        model_name: "yolov8n_pp".into(),
-        search_path: "test".into(),
-        save_path: "test".into(),
+        path: "test/yolov8n_pp.engine".into(),
         device_index: 0,
-        precision: Precision::FP16,
-        optimized_batch_size: 1,
-        max_batch_size: 1,
-        input_dtype: InputDataType::UINT8,
     };
     let mut b1_engine = Engine::new(&b1_options).unwrap();
+
+    println!("Input data type: {:?}", b1_engine.get_input_data_type());
 
     test_input_dim(&b1_engine);
     test_output_dim(&b1_engine);
 
-    let b2_options = Options {
-        model_name: "yolov8n_b2".into(),
-        optimized_batch_size: 2,
-        max_batch_size: 2,
-        ..b1_options.clone()
-    };
-    let mut b2_engine = Engine::new(&b2_options).unwrap();
-
-    let b4_options = Options {
-        model_name: "yolov8n_b4".into(),
-        optimized_batch_size: 4,
-        max_batch_size: 4,
-        ..b1_options.clone()
-    };
-    let mut b4_engine = Engine::new(&b4_options).unwrap();
-
-    let b8_options = Options {
-        model_name: "yolov8n_b8".into(),
-        optimized_batch_size: 8,
-        max_batch_size: 8,
-        ..b1_options.clone()
-    };
-    let mut b8_engine = Engine::new(&b8_options).unwrap();
-
-    let b16_options = Options {
-        model_name: "yolov8n_b16".into(),
-        optimized_batch_size: 16,
-        max_batch_size: 16,
-        ..b1_options.clone()
-    };
-    let mut b16_engine = Engine::new(&b16_options).unwrap();
+//    let b2_options = Options {
+//        path: "test/yolov8n_b2.engine".into(),
+//        device_index: 0,
+//    };
+//    let mut b2_engine = Engine::new(&b2_options).unwrap();
+//
+//    let b4_options = Options {
+//        path: "test/yolov8n_b4.engine".into(),
+//        device_index: 0,
+//    };
+//    let mut b4_engine = Engine::new(&b4_options).unwrap();
+//
+//    let b8_options = Options {
+//        path: "test/yolov8n_b8.engine".into(),
+//        device_index: 0,
+//    };
+//    let mut b8_engine = Engine::new(&b8_options).unwrap();
+//
+//    let b16_options = Options {
+//        path: "test/yolov8n_b16.engine".into(),
+//        device_index: 0,
+//    };
+//    let mut b16_engine = Engine::new(&b16_options).unwrap();
 
 //    test_output_features(&mut b1_engine);
 //    test_output_features(&mut b4_engine);
 
     benchmark_inference(&mut b1_engine, n);
-    benchmark_inference(&mut b2_engine, n / 2);
-    benchmark_inference(&mut b4_engine, n / 4);
-    benchmark_inference(&mut b8_engine, n / 8);
-    benchmark_inference(&mut b16_engine, n / 16);
+//    benchmark_inference(&mut b2_engine, n / 2);
+//    benchmark_inference(&mut b4_engine, n / 4);
+//    benchmark_inference(&mut b8_engine, n / 8);
+//    benchmark_inference(&mut b16_engine, n / 16);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,45 +1,41 @@
 //! Simple program to run tests and benchmark for libinfer.
 
-use approx::assert_relative_eq;
+//use approx::assert_relative_eq;
 use cxx::UniquePtr;
-use libinfer::{Engine, Options, InputDataType};
+use libinfer::{Engine, Options};
 use std::{
-    fs::File,
-    io::{BufRead, BufReader, Read},
-    iter::{repeat, zip},
-    path::PathBuf,
-    str::FromStr,
+    iter::{repeat},
     time::{Duration, Instant},
 };
 
-fn read_binary_f32(path: PathBuf) -> Vec<f32> {
-    let mut f = File::open(path).unwrap();
-    let mut input = Vec::new();
-    f.read_to_end(&mut input).unwrap();
-    let floats: Vec<f32> = input
-        .chunks_exact(4)
-        .map(|bs| f32::from_le_bytes(bs.try_into().unwrap()))
-        .collect();
-    floats
-}
-
-fn parse_file_to_float_vec(path: PathBuf) -> Vec<f32> {
-    let file = File::open(path).unwrap();
-    let reader = BufReader::new(file);
-
-    let mut float_vec = Vec::new();
-
-    for line in reader.lines() {
-        let line = line.unwrap();
-        let values: Vec<f32> = line
-            .split_whitespace()
-            .filter_map(|s| f32::from_str(s).ok())
-            .collect();
-
-        float_vec.extend(values);
-    }
-    float_vec
-}
+//fn read_binary_f32(path: PathBuf) -> Vec<f32> {
+//    let mut f = File::open(path).unwrap();
+//    let mut input = Vec::new();
+//    f.read_to_end(&mut input).unwrap();
+//    let floats: Vec<f32> = input
+//        .chunks_exact(4)
+//        .map(|bs| f32::from_le_bytes(bs.try_into().unwrap()))
+//        .collect();
+//    floats
+//}
+//
+//fn parse_file_to_float_vec(path: PathBuf) -> Vec<f32> {
+//    let file = File::open(path).unwrap();
+//    let reader = BufReader::new(file);
+//
+//    let mut float_vec = Vec::new();
+//
+//    for line in reader.lines() {
+//        let line = line.unwrap();
+//        let values: Vec<f32> = line
+//            .split_whitespace()
+//            .filter_map(|s| f32::from_str(s).ok())
+//            .collect();
+//
+//        float_vec.extend(values);
+//    }
+//    float_vec
+//}
 
 fn test_input_dim(engine: &UniquePtr<Engine>) {
     let input_dim = engine.get_input_dims();
@@ -140,41 +136,41 @@ fn main() {
     };
     let mut b1_engine = Engine::new(&b1_options).unwrap();
 
-    println!("Input data type: {:?}", b1_engine.get_input_data_type());
+//    println!("Input data type: {:?}", b1_engine.get_input_data_type());
 
     test_input_dim(&b1_engine);
     test_output_dim(&b1_engine);
 
-//    let b2_options = Options {
-//        path: "test/yolov8n_b2.engine".into(),
-//        device_index: 0,
-//    };
-//    let mut b2_engine = Engine::new(&b2_options).unwrap();
-//
-//    let b4_options = Options {
-//        path: "test/yolov8n_b4.engine".into(),
-//        device_index: 0,
-//    };
-//    let mut b4_engine = Engine::new(&b4_options).unwrap();
-//
-//    let b8_options = Options {
-//        path: "test/yolov8n_b8.engine".into(),
-//        device_index: 0,
-//    };
-//    let mut b8_engine = Engine::new(&b8_options).unwrap();
-//
-//    let b16_options = Options {
-//        path: "test/yolov8n_b16.engine".into(),
-//        device_index: 0,
-//    };
-//    let mut b16_engine = Engine::new(&b16_options).unwrap();
+    //    let b2_options = Options {
+    //        path: "test/yolov8n_b2.engine".into(),
+    //        device_index: 0,
+    //    };
+    //    let mut b2_engine = Engine::new(&b2_options).unwrap();
+    //
+    //    let b4_options = Options {
+    //        path: "test/yolov8n_b4.engine".into(),
+    //        device_index: 0,
+    //    };
+    //    let mut b4_engine = Engine::new(&b4_options).unwrap();
+    //
+    //    let b8_options = Options {
+    //        path: "test/yolov8n_b8.engine".into(),
+    //        device_index: 0,
+    //    };
+    //    let mut b8_engine = Engine::new(&b8_options).unwrap();
+    //
+    //    let b16_options = Options {
+    //        path: "test/yolov8n_b16.engine".into(),
+    //        device_index: 0,
+    //    };
+    //    let mut b16_engine = Engine::new(&b16_options).unwrap();
 
-//    test_output_features(&mut b1_engine);
-//    test_output_features(&mut b4_engine);
+    //    test_output_features(&mut b1_engine);
+    //    test_output_features(&mut b4_engine);
 
     benchmark_inference(&mut b1_engine, n);
-//    benchmark_inference(&mut b2_engine, n / 2);
-//    benchmark_inference(&mut b4_engine, n / 4);
-//    benchmark_inference(&mut b8_engine, n / 8);
-//    benchmark_inference(&mut b16_engine, n / 16);
+    //    benchmark_inference(&mut b2_engine, n / 2);
+    //    benchmark_inference(&mut b4_engine, n / 4);
+    //    benchmark_inference(&mut b8_engine, n / 8);
+    //    benchmark_inference(&mut b16_engine, n / 16);
 }


### PR DESCRIPTION
Removes the builder functionality. There are a lot of options to choosing how to build a TRT engine, and one is better served by using `trtexec` or the Python library in order to do this. `libinfer` is now solely focused on loading pre-existing engines and giving the ability to run inference.