### PR TITLE
fix: flake for aarch64

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       let
         pkgs = import nixpkgs { inherit system; };
         cudaPackages = if system == "aarch64-linux" then jetpack-nixos.legacyPackages.aarch64-linux.cudaPackages else pkgs.cudaPackages_11;
+        tensorrt = if system == "aarch64-linux" then jetpack-nixos.legacyPackages.aarch64-linux.cudaPackages.tensorrt else pkgs.cudaPackages_11.tensorrt_8_6;
         l4t-cuda = jetpack-nixos.legacyPackages.aarch64-linux.l4t-cuda;
         inherit (cudaPackages) cudatoolkit tensorrt_8_6 cudnn cuda_cudart;
 
@@ -28,7 +29,7 @@
           openssl
           pkg-config
           cudatoolkit
-          tensorrt_8_6
+          tensorrt
           rustc
           cargo
           rustfmt
@@ -42,10 +43,10 @@
           default = pkgs.mkShell {
             nativeBuildInputs = inputs;
             LIBCLANG_PATH = pkgs.lib.optionalString pkgs.stdenv.isLinux "${pkgs.libclang.lib}/lib/";
-            TENSORRT_LIBRARIES = "${tensorrt_8_6}/lib";
+            TENSORRT_LIBRARIES = "${tensorrt}/lib";
             CUDA_INCLUDE_DIRS = "${cudatoolkit}/include";
             CUDA_LIBRARIES = "${cudatoolkit}/lib";
-            LD_LIBRARY_PATH = "${tensorrt_8_6}/lib";
+            LD_LIBRARY_PATH = "${tensorrt}/lib";
           };
         };
       });


### PR DESCRIPTION
Fixes the flake for entering a dev shell on jetpack devices.