### PR TITLE
Fix/efficientnms

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -80,7 +80,7 @@ Engine::~Engine() {
 
 void Engine::load() {
   // Initialize plugins
-  initLibNvInferPlugins(&m_logger, "");
+  initLibNvInferPlugins(&mLogger, "");
 
 
   // Read the serialized model from disk


### PR DESCRIPTION
Added a one-liner to initialize trt plugins. Reference: https://forums.developer.nvidia.com/t/getplugincreator-could-not-find-plugin-efficientnms-trt-version-1-error-with-c-api-but-works-fine-with-python-api/271361/6?u=jacob76
