### PR TITLE
feat: Heterogeneously dynamic inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,40 +15,57 @@ To use this library, you'll need:
 Add to your `Cargo.toml`:
 ```toml
 [dependencies]
-libinfer = "0.0.3"
+libinfer = "0.0.5"
 ```
 
 ## Usage
 The goal of the API is to keep as much processing in Rust land as possible. Here is a sample usage:
 
 ```rust
+use libinfer::{Engine, Options, InputTensor, TensorDataType};
+
 let options = Options {
-    path: "yolov8n.engine".into(),
+    path: "model.engine".into(),
     device_index: 0,
 };
 let mut engine = Engine::new(&options).unwrap();
 
-// Get input dimensions of the engine as [Channels, Height, Width]
-let dims = engine.get_input_dims();
+// Query per-input shape profiles (includes batch dimension)
+let profiles = engine.get_input_shape_profiles();
+let input_infos = engine.get_input_dims(); // dims without batch
 
-// Construct a dummy input (uint8 or float32 depending on model)
-let input_size = dims.iter().fold(1, |acc, &e| acc * e as usize);
-let input = InputTensor {
-    name: "input".to_string();
-    data: vec![0u8; input_size];
+// Construct inputs using each input's optimal shape
+let input_tensors: Vec<InputTensor> = profiles.iter().zip(input_infos.iter()).map(|(profile, info)| {
+    let shape = &profile.opt_shape;
+    let dtype_size = match info.dtype {
+        TensorDataType::FP32 => 4,
+        TensorDataType::UINT8 | TensorDataType::BOOL => 1,
+        TensorDataType::INT64 => 8,
+        _ => 1,
+    };
+    let byte_count: usize = shape.iter().map(|&d| d as usize).product::<usize>() * dtype_size;
+    InputTensor {
+        name: info.name.clone(),
+        data: vec![0u8; byte_count],
+        dtype: info.dtype.clone(),
+    }
+}).collect();
 
 // Run inference
-let output = engine.pin_mut().infer(&input).unwrap();
+let outputs = engine.pin_mut().infer(&input_tensors).unwrap();
 
-// Postprocess the output according to your model's output format
-// ...
+// Process outputs
+for output in &outputs {
+    println!("Output '{}': {} bytes", output.name, output.data.len());
+}
 ```
 
 This library is intended to be used with pre-built TensorRT engines created by the Python API or the `trtexec` CLI tool for the target device.
 
 ## Features
-- Support for both fixed and dynamic batch sizes
-- Automatic handling of different input data types (UINT8, FP32)
+- Heterogeneous per-input dynamic shapes — each input tensor can have its own independent dynamic dimension
+- Per-input shape profiles (`get_input_shape_profiles()`) exposing min/opt/max shapes from the TensorRT optimization profile
+- Support for UINT8, FP32, INT64, and BOOL input data types
 - Direct access to model dimensions and parameters
 - Error handling via Rust's `Result` type
 - Logging integration with `RUST_LOG` environment variable
@@ -56,8 +73,8 @@ This library is intended to be used with pre-built TensorRT engines created by t
 ## Examples
 Check the `examples/` directory for working examples:
 - `basic.rs`: Simple inference example
-- `benchmark.rs`: Performance benchmarking with various batch sizes
-- `dynamic.rs`: Working with dynamic batch sizes
+- `benchmark.rs`: Performance benchmarking with per-input shape profiling (tests min/opt/max automatically)
+- `dynamic.rs`: Working with heterogeneous per-input dynamic shapes
 - `functional_test.rs`: Testing correctness of model outputs
 
 Run an example with:
@@ -87,6 +104,7 @@ No `cudaStreamSynchronize` is needed between H2D copies and `enqueueV3`. This is
 A post-inference `cudaStreamSynchronize` is still required to ensure D2H output copies are complete before reading results. `infer()` handles this internally.
 
 ## Current Limitations
+- Each input tensor supports at most one dynamic dimension (batch). Multiple dynamic dims per input would require explicit shape specification.
 - The underlying engine code is not threadsafe (and the Rust binding does not implement `Sync`)
 - Engine instances are `Send` but not `Sync`
 - Input and output data transfers happen on the CPU-GPU boundary

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,29 +1,18 @@
 //! # Benchmark Example
 //!
 //! Benchmarks inference speed of TensorRT engines with various batch sizes.
+//! Supports engines with heterogeneous per-input dynamic shapes.
 //!
 //! ## Usage
 //! ```bash
-//! # Run with a single engine file
-//! cargo run --example benchmark -- --path /path/to/your/model.engine --iterations 100
-//!
-//! # Run with a directory containing multiple batch sizes
-//! cargo run --example benchmark -- --path /directory/with/engines --iterations 100
+//! cargo run --release --example benchmark -- --path /path/to/model.engine --iterations 1000
 //! ```
-//!
-//! ## Engine Requirements
-//! This example expects:
-//! - When targeting a directory, it looks for: yolov8n.engine, yolov8n_b2.engine, etc.
-//! - You must provide your own TensorRT engine files
-//! - The example will adapt to any model type, not just YOLOv8
-//!
 
 use clap::Parser;
 use cxx::UniquePtr;
 use libinfer::{Engine, TensorDataType, Options};
 use libinfer::ffi::InputTensor;
 use std::{
-    iter::repeat,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -32,96 +21,101 @@ use tracing_subscriber::{FmtSubscriber, EnvFilter};
 
 #[derive(Parser, Debug)]
 struct Args {
-    /// Path to the directory containing engine files.
-    #[arg(short, long, value_name = "PATH", default_value = ".", value_parser)]
+    /// Path to the engine file.
+    #[arg(short, long, value_name = "PATH", value_parser)]
     path: PathBuf,
 
     /// Number of iterations (default: 32768)
     #[arg(short, long, value_name = "ITERATIONS", default_value_t = 1 << 15)]
     iterations: usize,
+
+    /// GPU device index
+    #[arg(short, long, default_value_t = 0)]
+    device: u32,
 }
 
-fn benchmark_inference(engine: &mut UniquePtr<Engine>, num_runs: usize) {
-    let input_dims = engine.get_input_dims();
-    let batch_size = engine.get_batch_dims().opt; // Use optimal batch size from engine
-    
-    // Create input tensors for all inputs with per-tensor data types
-    let input_tensors: Vec<InputTensor> = input_dims.iter().map(|input_info| {
-        info!("Input tensor '{}' has dims {:?} and dtype {:?}", input_info.name, input_info.dims, input_info.dtype);
+/// Build input tensors using per-input shape profiles at the given phase (min/opt/max).
+fn build_inputs(engine: &UniquePtr<Engine>, phase: &str) -> Vec<InputTensor> {
+    let profiles = engine.get_input_shape_profiles();
+    let input_infos = engine.get_input_dims();
 
-        let input_len = input_info.dims.iter().fold(1, |acc, &e| acc * e as usize) * batch_size as usize;
-        
-        let input_data: Vec<u8> = match input_info.dtype {
-            TensorDataType::UINT8 => repeat(0).take(input_len).collect(),
-            TensorDataType::FP32 => repeat(0).take(4 * input_len).collect(),
-            TensorDataType::INT64 => repeat(0).take(8 * input_len).collect(),
-            TensorDataType::BOOL => repeat(0).take(input_len).collect(),
-            _ => {
-                error!("Unsupported input data type");
-                std::process::exit(1);
-            },
+    profiles.iter().zip(input_infos.iter()).map(|(profile, info)| {
+        let shape = match phase {
+            "min" => &profile.min_shape,
+            "opt" => &profile.opt_shape,
+            "max" => &profile.max_shape,
+            _ => &profile.opt_shape,
         };
 
-        let input = InputTensor {
-            name: input_info.name.clone(),
-            data: input_data,
-            dtype: input_info.dtype.clone(),
+        let dtype_size: usize = match info.dtype {
+            TensorDataType::UINT8 | TensorDataType::BOOL => 1,
+            TensorDataType::FP32 => 4,
+            TensorDataType::INT64 => 8,
+            _ => 1,
         };
-        
-        info!("Created input tensor '{}' with {} elements (dtype: {:?})", input.name, input.data.len(), input.dtype);
 
-        input
-    }).collect();
+        let elem_count: usize = shape.iter().map(|&d| d as usize).product();
+        let dynamic_tag = if profile.has_dynamic_shape { "DYNAMIC" } else { "STATIC" };
 
-    // Warmup.
-    info!("Warming up inference codepath...");
-    for i in 0..1024 {
-        let _output = engine.pin_mut().infer(&input_tensors).unwrap();
-        if i % 100 == 0 && i > 0 {
-            info!("Warmup progress: {}/1024", i);
+        info!("  {} '{}': shape={:?} ({} bytes)",
+             dynamic_tag, profile.name, shape, elem_count * dtype_size);
+
+        InputTensor {
+            name: info.name.clone(),
+            data: vec![0u8; elem_count * dtype_size],
+            dtype: info.dtype.clone(),
         }
+    }).collect()
+}
+
+fn benchmark_inference(engine: &mut UniquePtr<Engine>, input_tensors: &Vec<InputTensor>, num_runs: usize) {
+    // Warmup
+    info!("Warming up (1024 iterations)...");
+    for _ in 0..1024 {
+        let _ = engine.pin_mut().infer(input_tensors).unwrap();
     }
 
-    // Measure.
-    info!("Beginning {num_runs} inference runs...");
-    let mut latencies = Vec::new();
+    // Measure
+    info!("Running {num_runs} iterations...");
+    let mut latencies = Vec::with_capacity(num_runs);
     let mut total_time = Duration::ZERO;
-    
+
     for i in 0..num_runs {
         let start = Instant::now();
-        let _output = engine.pin_mut().infer(&input_tensors).unwrap();
+        let _output = engine.pin_mut().infer(input_tensors).unwrap();
         let elapsed = start.elapsed();
         latencies.push(elapsed);
         total_time += elapsed;
-        
-        // Progress logging every 10% or every 1000 iterations, whichever is more frequent
+
         let progress_interval = std::cmp::min(num_runs / 10, 1000).max(1);
         if i % progress_interval == 0 && i > 0 {
-            let avg_latency = total_time.as_secs_f32() / i as f32;
-            let remaining_runs = num_runs - i;
-            let eta_seconds = avg_latency * remaining_runs as f32;
-            info!("Progress: {}/{} runs ({:.1}%), avg latency: {:.3}ms, ETA: {:.1}s", 
-                  i, num_runs, (i as f32 / num_runs as f32) * 100.0,
-                  avg_latency * 1000.0, eta_seconds);
+            let avg_ms = total_time.as_secs_f64() / i as f64 * 1000.0;
+            let remaining = num_runs - i;
+            let eta = avg_ms * remaining as f64 / 1000.0;
+            info!("  {}/{} ({:.1}%) avg={:.3}ms ETA={:.1}s",
+                  i, num_runs, (i as f64 / num_runs as f64) * 100.0, avg_ms, eta);
         }
     }
 
-    let total_latency = latencies.iter().map(|t| t.as_secs_f32()).sum::<f32>();
-    let average_batch_latency = total_latency / latencies.len() as f32;
-    let average_batch_framerate = 1.0 / average_batch_latency;
-    let average_frame_latency = total_latency / (latencies.len() as f32 * batch_size as f32);
-    let average_frame_framerate = 1.0 / average_frame_latency;
+    latencies.sort();
+    let total_secs = total_time.as_secs_f64();
+    let avg_ms = total_secs / num_runs as f64 * 1000.0;
+    let p50_ms = latencies[num_runs / 2].as_secs_f64() * 1000.0;
+    let p99_ms = latencies[num_runs * 99 / 100].as_secs_f64() * 1000.0;
+    let min_ms = latencies[0].as_secs_f64() * 1000.0;
+    let max_ms = latencies[num_runs - 1].as_secs_f64() * 1000.0;
 
-    info!("inference calls    : {}", num_runs);
-    info!("total latency      : {}", total_latency);
-    info!("avg. frame latency : {}", average_frame_latency);
-    info!("avg. frame fps     : {}", average_frame_framerate);
-    info!("avg. batch latency : {}", average_batch_latency);
-    info!("avg. batch fps     : {}", average_batch_framerate);
+    info!("Results:");
+    info!("  iterations : {}", num_runs);
+    info!("  avg        : {:.3}ms", avg_ms);
+    info!("  p50        : {:.3}ms", p50_ms);
+    info!("  p99        : {:.3}ms", p99_ms);
+    info!("  min        : {:.3}ms", min_ms);
+    info!("  max        : {:.3}ms", max_ms);
+    info!("  throughput : {:.1} infer/s", num_runs as f64 / total_secs);
 }
 
 fn main() {
-    // Initialize tracing subscriber for logging
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .with_max_level(Level::INFO)
@@ -131,114 +125,54 @@ fn main() {
 
     let args = Args::parse();
 
-    // If the exact path was specified, use it directly
-    if args.path.is_file() {
-        info!("Loading engine from {}", args.path.display());
-        let options = Options {
-            path: args.path.to_string_lossy().to_string(),
-            device_index: 0,
-        };
-        let mut engine = match Engine::new(&options) {
-            Ok(engine) => engine,
-            Err(e) => {
-                error!("Failed to load engine: {e}");
-                std::process::exit(1);
-            }
-        };
-
-        let input_dims = engine.get_input_dims();
-        if !input_dims.is_empty() {
-            info!("Input data types: {:?}", input_dims.iter().map(|t| (&t.name, &t.dtype)).collect::<Vec<_>>());
-        }
-        benchmark_inference(&mut engine, args.iterations);
-        return;
-    }
-
-    // Otherwise, look for engines with different batch sizes
-    let b1_path = args.path.join("yolov8n.engine");
-    if !b1_path.exists() {
-        error!("Engine file not found: {}", b1_path.display());
-        error!("Please specify a path to a valid engine file or directory containing engine files");
+    if !args.path.is_file() {
+        error!("Engine file not found: {}", args.path.display());
         std::process::exit(1);
     }
 
-    let b1_options = Options {
-        path: b1_path.to_string_lossy().to_string(),
-        device_index: 0,
-    };
-    let mut b1_engine = match Engine::new(&b1_options) {
-        Ok(engine) => engine,
-        Err(e) => {
-            error!("Failed to load engine: {e}");
-            std::process::exit(1);
-        }
+    info!("Loading engine: {}", args.path.display());
+    let options = Options {
+        path: args.path.to_string_lossy().to_string(),
+        device_index: args.device,
     };
 
-    let input_dims = b1_engine.get_input_dims();
-    if !input_dims.is_empty() {
-        info!("Input data types: {:?}", input_dims.iter().map(|t| (&t.name, &t.dtype)).collect::<Vec<_>>());
-    }
-    info!("\nRunning benchmark for batch size 1");
-    benchmark_inference(&mut b1_engine, args.iterations);
+    let mut engine = Engine::new(&options).unwrap_or_else(|e| {
+        error!("Failed to load engine: {e}");
+        std::process::exit(1);
+    });
 
-    // Try to load other batch sizes if they exist
-    let b2_path = args.path.join("yolov8n_b2.engine");
-    if b2_path.exists() {
-        let b2_options = Options {
-            path: b2_path.to_string_lossy().to_string(),
-            device_index: 0,
-        };
-        match Engine::new(&b2_options) {
-            Ok(mut b2_engine) => {
-                info!("\nRunning benchmark for batch size 2");
-                benchmark_inference(&mut b2_engine, args.iterations / 2);
-            },
-            Err(e) => error!("Failed to load b2 engine: {e}")
+    // Display shape profiles
+    let profiles = engine.get_input_shape_profiles();
+    info!("Inputs: {}", profiles.len());
+    for p in &profiles {
+        if p.has_dynamic_shape {
+            info!("  '{}': DYNAMIC min={:?} opt={:?} max={:?}",
+                 p.name, p.min_shape, p.opt_shape, p.max_shape);
+        } else {
+            info!("  '{}': STATIC shape={:?}", p.name, p.min_shape);
         }
     }
 
-    let b4_path = args.path.join("yolov8n_b4.engine");
-    if b4_path.exists() {
-        let b4_options = Options {
-            path: b4_path.to_string_lossy().to_string(),
-            device_index: 0,
-        };
-        match Engine::new(&b4_options) {
-            Ok(mut b4_engine) => {
-                info!("\nRunning benchmark for batch size 4");
-                benchmark_inference(&mut b4_engine, args.iterations / 4);
-            },
-            Err(e) => error!("Failed to load b4 engine: {e}")
-        }
+    let output_infos = engine.get_output_dims();
+    info!("Outputs: {}", output_infos.len());
+    for o in &output_infos {
+        info!("  '{}': dims={:?} dtype={:?}", o.name, o.dims, o.dtype);
     }
 
-    let b8_path = args.path.join("yolov8n_b8.engine");
-    if b8_path.exists() {
-        let b8_options = Options {
-            path: b8_path.to_string_lossy().to_string(),
-            device_index: 0,
-        };
-        match Engine::new(&b8_options) {
-            Ok(mut b8_engine) => {
-                info!("\nRunning benchmark for batch size 8");
-                benchmark_inference(&mut b8_engine, args.iterations / 8);
-            },
-            Err(e) => error!("Failed to load b8 engine: {e}")
-        }
-    }
+    // Check if any inputs are dynamic
+    let has_dynamic = profiles.iter().any(|p| p.has_dynamic_shape);
 
-    let b16_path = args.path.join("yolov8n_b16.engine");
-    if b16_path.exists() {
-        let b16_options = Options {
-            path: b16_path.to_string_lossy().to_string(),
-            device_index: 0,
-        };
-        match Engine::new(&b16_options) {
-            Ok(mut b16_engine) => {
-                info!("\nRunning benchmark for batch size 16");
-                benchmark_inference(&mut b16_engine, args.iterations / 16);
-            },
-            Err(e) => error!("Failed to load b16 engine: {e}")
+    if has_dynamic {
+        // Benchmark at min, opt, and max shapes
+        for phase in &["min", "opt", "max"] {
+            info!("\n=== Benchmark at {} shapes ===", phase);
+            let inputs = build_inputs(&engine, phase);
+            benchmark_inference(&mut engine, &inputs, args.iterations);
         }
+    } else {
+        // Static engine — single benchmark
+        info!("\n=== Benchmark (static shapes) ===");
+        let inputs = build_inputs(&engine, "opt");
+        benchmark_inference(&mut engine, &inputs, args.iterations);
     }
 }

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -1,10 +1,10 @@
 //! # Dynamic Batch Size Example
 //!
-//! Demonstrates using a TensorRT engine with dynamic batch sizes.
+//! Demonstrates using a TensorRT engine with per-input dynamic batch sizes.
 //! This example shows how to:
-//! 1. Check the supported batch size range of an engine
-//! 2. Create inputs with different batch sizes
-//! 3. Run inference with varying batch sizes
+//! 1. Query per-input shape profiles to see which inputs are dynamic
+//! 2. Create inputs with independent batch sizes per tensor
+//! 3. Run inference with heterogeneous dynamic batches
 //!
 //! ## Usage
 //! ```bash
@@ -15,9 +15,12 @@
 //! - You must provide your own TensorRT engine file
 //! - The engine must be built with dynamic batch size support
 //! - Normal fixed-batch engines will display a warning message
-//! - To create a dynamic batch engine, use TensorRT's Python API or trtexec with appropriate flags:
+//! - To create a heterogeneous dynamic batch engine, use trtexec with per-input shapes:
 //!   ```
-//!   trtexec --onnx=model.onnx --saveEngine=dynamic_model.engine --minShapes=input:1x3x640x640 --optShapes=input:8x3x640x640 --maxShapes=input:16x3x640x640
+//!   trtexec --onnx=model.onnx --saveEngine=model.engine \
+//!     --minShapes=frame:1x3x518x518,crops:1x3x224x224,modality:1 \
+//!     --optShapes=frame:1x3x518x518,crops:16x3x224x224,modality:1 \
+//!     --maxShapes=frame:1x3x518x518,crops:64x3x224x224,modality:1
 //!   ```
 
 use clap::Parser;
@@ -40,7 +43,6 @@ struct Args {
 }
 
 fn main() {
-    // Initialize tracing subscriber for logging
     let subscriber = FmtSubscriber::builder()
         .with_env_filter(EnvFilter::from_default_env())
         .with_max_level(Level::INFO)
@@ -52,13 +54,11 @@ fn main() {
 
     info!("Loading TensorRT engine from: {}", args.path.display());
 
-    // Create engine options
     let options = Options {
         path: args.path.to_string_lossy().to_string(),
         device_index: args.device,
     };
 
-    // Load the engine
     let mut engine = Engine::new(&options).unwrap_or_else(|e| {
         error!("Failed to load engine: {e}");
         std::process::exit(1);
@@ -66,81 +66,79 @@ fn main() {
 
     let input_infos = engine.get_input_dims();
     let output_infos = engine.get_output_dims();
-    let batch_dims = engine.get_batch_dims();
+    let profiles = engine.get_input_shape_profiles();
 
-    // Print model information
     info!("Engine loaded successfully");
     info!("Number of inputs: {}", input_infos.len());
     info!("Number of outputs: {}", output_infos.len());
-    info!("Batch dimensions: min={}, optimal={}, max={}",
-         batch_dims.min, batch_dims.opt, batch_dims.max);
 
-    // Check if this engine truly supports dynamic batch sizes
-    if batch_dims.min == batch_dims.max {
-        warn!("This engine does not support dynamic batch sizes!");
-        warn!("All batch dimensions are fixed at {}", batch_dims.min);
-        warn!("To test dynamic batching, you need an engine built with dynamic shapes.");
+    // Display per-input shape profiles
+    let mut has_dynamic = false;
+    for profile in &profiles {
+        if profile.has_dynamic_shape {
+            has_dynamic = true;
+            info!("Input '{}': DYNAMIC min={:?} opt={:?} max={:?}",
+                 profile.name, profile.min_shape, profile.opt_shape, profile.max_shape);
+        } else {
+            info!("Input '{}': STATIC shape={:?}",
+                 profile.name, profile.min_shape);
+        }
+    }
+
+    if !has_dynamic {
+        warn!("This engine has no dynamic inputs. Nothing to test.");
         return;
     }
 
-    // Test different batch sizes within the supported range
-    let batch_sizes_to_test = [
-        batch_dims.min,
-        batch_dims.opt,
-        batch_dims.max,
-    ];
+    // Test with min, opt, and max dynamic dim values
+    for phase in &["min", "opt", "max"] {
+        info!("\n--- Testing with {} shapes ---", phase);
 
-    for &batch_size in &batch_sizes_to_test {
-        info!("\nTesting batch size: {}", batch_size);
+        // Build per-input tensors using each input's own profile
+        let input_tensors: Vec<InputTensor> = profiles.iter().zip(input_infos.iter()).map(|(profile, info)| {
+            let shape = match *phase {
+                "min" => &profile.min_shape,
+                "opt" => &profile.opt_shape,
+                "max" => &profile.max_shape,
+                _ => unreachable!(),
+            };
 
-        // Create input tensors for all inputs
-        let input_tensors: Vec<InputTensor> = input_infos.iter().map(|info| {
             let dtype_size = match info.dtype {
                 TensorDataType::UINT8 => 1,
                 TensorDataType::FP32 => 4,
                 TensorDataType::INT64 => 8,
                 TensorDataType::BOOL => 1,
-                _ => {
-                    error!("Unsupported data type: {:?}", info.dtype);
-                    1 // Default to 1 byte to avoid panic
-                }
+                _ => 1,
             };
 
-            let elem_count = if !input_infos.is_empty() {
-                info.dims.iter().fold(1, |acc, &e| acc * e as usize)
-            } else {
-                0
-            };
+            let elem_count: usize = shape.iter().map(|&d| d as usize).product();
+
+            info!("  Input '{}': shape={:?} ({} bytes)",
+                 profile.name, shape, elem_count * dtype_size);
 
             InputTensor {
                 name: info.name.clone(),
-                data: vec![0u8; elem_count * dtype_size * batch_size as usize],
+                data: vec![0u8; elem_count * dtype_size],
                 dtype: info.dtype.clone(),
             }
         }).collect();
-
-        info!("Total input size across all tensors: {} bytes", input_tensors.iter().map(|t| t.data.len()).sum::<usize>());
 
         // Warmup
         for _ in 0..5 {
             let _ = engine.pin_mut().infer(&input_tensors);
         }
 
-        // Measure inference time
         let start = Instant::now();
         let result = engine.pin_mut().infer(&input_tensors);
         let elapsed = start.elapsed();
 
         match result {
             Ok(outputs) => {
-                info!("Inference successful!");
-                info!("Number of output tensors: {}", outputs.len());
-                for (i, output) in outputs.iter().enumerate() {
-                    info!("Output {}: '{}' with {} elements", i, output.name, output.data.len());
+                info!("Inference successful! ({:?})", elapsed);
+                for output in outputs.iter() {
+                    info!("  Output '{}': {} bytes (dtype: {:?})",
+                         output.name, output.data.len(), output.dtype);
                 }
-                info!("Inference time: {:?}", elapsed);
-                info!("Throughput: {:.2} items/second",
-                     batch_size as f64 / elapsed.as_secs_f64());
             }
             Err(e) => {
                 error!("Inference failed: {}", e);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -477,10 +477,6 @@ rust::Vec<InputShapeProfile> Engine::_get_input_shape_profiles() const {
     profile.name = metadata.name;
     profile.has_dynamic_shape = metadata.hasDynamicShape;
 
-    resize(profile.min_shape, 0);
-    resize(profile.opt_shape, 0);
-    resize(profile.max_shape, 0);
-
     for (int j = 0; j < metadata.minShape.nbDims; ++j) {
       profile.min_shape.push_back(static_cast<int32_t>(metadata.minShape.d[j]));
     }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -187,85 +187,94 @@ void Engine::load() {
   checkCudaErrorCode(cudaStreamCreate(&mInferenceCudaStream));
 
   // Allocate GPU memory for input and output buffers.
-  mOutputLengths.clear();
   mTensorMetadata.clear();
   mTensorMetadata.reserve(mEngine->getNbIOTensors());
-  
+
   for (int i = 0; i < mEngine->getNbIOTensors(); ++i) {
     const auto tensorName = mEngine->getIOTensorName(i);
     mIOTensorNames.emplace_back(tensorName);
     const auto tensorType = mEngine->getTensorIOMode(tensorName);
     const auto tensorShape = mEngine->getTensorShape(tensorName);
     const auto tensorDataType = mEngine->getTensorDataType(tensorName);
-    
-    // Store tensor metadata to avoid repeated TensorRT queries during inference
+
     TensorMetadata metadata;
     metadata.name = std::string(tensorName);
     metadata.ioMode = tensorType;
     metadata.dataType = tensorDataType;
     metadata.dataTypeSize = getDataTypeSize(toTensorDataType(tensorDataType));
     metadata.dims = tensorShape;
-    mTensorMetadata.push_back(std::move(metadata));
+
     if (tensorType == TensorIOMode::kINPUT) {
-      // Store the input dims for later use.
       mInputDims.push_back(tensorShape);
-      const size_t inputDataTypeSize = metadata.dataTypeSize;
 
-      mMinBatchSize =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMIN)
-              .d[0];
-      mOptBatchSize =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kOPT)
-              .d[0];
-      mMaxBatchSize =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMAX)
-              .d[0];
+      // Query per-input profile shapes
+      metadata.minShape = mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMIN);
+      metadata.optShape = mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kOPT);
+      metadata.maxShape = mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMAX);
 
-      // multiply tensorShape dimensions except for the batch dimension
-      uint32_t inputLen = 1;
-      for (int j = 1; j < tensorShape.nbDims; ++j) {
-        // We ignore j = 0 because that is the batch size, and we will take that
-        // into account when sizing the buffer.
-        inputLen *= tensorShape.d[j];
+      // Detect dynamic dimensions and precompute inference fields
+      metadata.hasDynamicShape = false;
+      metadata.dynamicDimIndex = -1;
+      metadata.staticByteCount = metadata.dataTypeSize;
+
+      for (int j = 0; j < tensorShape.nbDims; ++j) {
+        if (tensorShape.d[j] == -1) {
+          if (metadata.hasDynamicShape) {
+            throw std::runtime_error(
+                "Input '" + metadata.name + "' has multiple dynamic dimensions; "
+                "exactly 1 is supported for automatic shape inference");
+          }
+          metadata.hasDynamicShape = true;
+          metadata.dynamicDimIndex = j;
+          // Don't multiply this dim into staticByteCount
+        } else {
+          metadata.staticByteCount *= tensorShape.d[j];
+        }
       }
 
-      inputLen *= inputDataTypeSize; // Account for data type size
-      inputLen *= mMaxBatchSize; // Account for max batch size
+      // Allocate buffer using this input's own max shape
+      size_t inputBufferBytes = metadata.dataTypeSize;
+      for (int j = 0; j < metadata.maxShape.nbDims; ++j) {
+        inputBufferBytes *= metadata.maxShape.d[j];
+      }
 
-      // Allocate as much memory for the largest supported batch size.
       checkCudaErrorCode(
-        cudaMallocAsync(&mBuffers[i],
-          inputLen,
-          mInferenceCudaStream
-        )
+        cudaMallocAsync(&mBuffers[i], inputBufferBytes, mInferenceCudaStream)
       );
     } else if (tensorType == TensorIOMode::kOUTPUT) {
-      const size_t outputDataTypeSize = metadata.dataTypeSize;
-
-      // The binding is an output
-      uint32_t outputLen = 1;
       mOutputDims.push_back(tensorShape);
-
-      for (int j = 1; j < tensorShape.nbDims; ++j) {
-        // We ignore j = 0 because that is the batch size, and we will take that
-        // into account when sizing the buffer.
-        outputLen *= tensorShape.d[j];
-      }
-
-      mOutputLengths.push_back(outputLen);
-
-      outputLen *= outputDataTypeSize; // Account for data type size
-      outputLen *= mMaxBatchSize; // Account for max batch size
-
-      // Allocate as much memory for the largest supported batch size.
-      checkCudaErrorCode(cudaMallocAsync(
-          &mBuffers[i], 
-          outputLen,
-          mInferenceCudaStream));
+      // Output buffers allocated after the loop via shape propagation
     } else {
       throw std::runtime_error(
           "Error, IO Tensor is neither an input or output!");
     }
+
+    // Push metadata after all fields are populated
+    mTensorMetadata.push_back(std::move(metadata));
+  }
+
+  // Allocate output buffers by setting all inputs to their max shapes
+  // and querying TensorRT for the resulting output shapes.
+  for (const auto &meta : mTensorMetadata) {
+    if (meta.ioMode == TensorIOMode::kINPUT) {
+      mContext->setInputShape(meta.name.c_str(), meta.maxShape);
+    }
+  }
+
+  for (int i = 0; i < static_cast<int>(mTensorMetadata.size()); ++i) {
+    const auto &meta = mTensorMetadata[i];
+    if (meta.ioMode != TensorIOMode::kOUTPUT) continue;
+
+    nvinfer1::Dims maxOutputShape = mContext->getTensorShape(meta.name.c_str());
+
+    size_t outputBufferBytes = meta.dataTypeSize;
+    for (int j = 0; j < maxOutputShape.nbDims; ++j) {
+      outputBufferBytes *= maxOutputShape.d[j];
+    }
+
+    checkCudaErrorCode(
+      cudaMallocAsync(&mBuffers[i], outputBufferBytes, mInferenceCudaStream)
+    );
   }
 
   // Ensure all async allocations are complete before returning.
@@ -279,70 +288,70 @@ rust::Vec<OutputTensor> Engine::infer(const rust::Vec<InputTensor> &input) {
     inputMap[std::string(tensorInput.name)] = &tensorInput;
   }
 
-  // Track the batch size (should be consistent across all inputs)
-  int32_t batchSize = -1;
-  
-  // Process each input tensor using cached metadata
+  // Process each input tensor using cached metadata (per-input shape resolution)
   for (int i = 0; i < static_cast<int>(mTensorMetadata.size()); ++i) {
     const auto &metadata = mTensorMetadata[i];
-    
+
     if (metadata.ioMode != TensorIOMode::kINPUT) {
-      continue; // If not a tensor input skip
+      continue;
     }
-    
-    // Find the corresponding input data
+
     auto it = inputMap.find(metadata.name);
     if (it == inputMap.end()) {
       throw std::runtime_error("Missing input tensor: " + metadata.name);
     }
-    
+
     const auto &tensorInput = *it->second;
-    const auto &dims = metadata.dims;
-    
-    // Calculate expected tensor size (excluding batch dimension)
-    size_t tensorSize = 1;
-    for (int d = 1; d < dims.nbDims; ++d) {
-      tensorSize *= dims.d[d];
-    }
-    tensorSize *= metadata.dataTypeSize; // Account for data type size
-    
-    // Calculate batch size from input data
-    int32_t currentBatchSize = tensorInput.data.size() / tensorSize;
-    
-    if (batchSize == -1) {
-      batchSize = currentBatchSize;
-      
-      // Validate batch size constraints
-      if (batchSize < mMinBatchSize) {
-        throw std::runtime_error("Input batch size " + std::to_string(batchSize) + 
-                               " is less than minimum: " + std::to_string(mMinBatchSize));
+    nvinfer1::Dims actualShape = metadata.dims;
+
+    if (metadata.hasDynamicShape) {
+      // Resolve the single dynamic dimension via precomputed staticByteCount
+      if (tensorInput.data.size() % metadata.staticByteCount != 0) {
+        throw std::runtime_error(
+            "Input tensor '" + metadata.name + "' data size (" +
+            std::to_string(tensorInput.data.size()) +
+            " bytes) is not divisible by static element size (" +
+            std::to_string(metadata.staticByteCount) + " bytes)");
       }
-      if (batchSize > mMaxBatchSize) {
-        throw std::runtime_error("Input batch size " + std::to_string(batchSize) + 
-                               " is greater than maximum: " + std::to_string(mMaxBatchSize));
+
+      int32_t dynamicDimValue = static_cast<int32_t>(
+          tensorInput.data.size() / metadata.staticByteCount);
+
+      if (dynamicDimValue < metadata.minShape.d[metadata.dynamicDimIndex]) {
+        throw std::runtime_error(
+            "Input '" + metadata.name + "' dynamic dim[" +
+            std::to_string(metadata.dynamicDimIndex) + "] = " +
+            std::to_string(dynamicDimValue) + " is less than min profile value " +
+            std::to_string(metadata.minShape.d[metadata.dynamicDimIndex]));
       }
-    } else if (currentBatchSize != batchSize) {
-      throw std::runtime_error("Inconsistent batch sizes across input tensors");
+      if (dynamicDimValue > metadata.maxShape.d[metadata.dynamicDimIndex]) {
+        throw std::runtime_error(
+            "Input '" + metadata.name + "' dynamic dim[" +
+            std::to_string(metadata.dynamicDimIndex) + "] = " +
+            std::to_string(dynamicDimValue) + " exceeds max profile value " +
+            std::to_string(metadata.maxShape.d[metadata.dynamicDimIndex]));
+      }
+
+      actualShape.d[metadata.dynamicDimIndex] = dynamicDimValue;
+    } else {
+      // Static input: validate exact size
+      if (tensorInput.data.size() != metadata.staticByteCount) {
+        throw std::runtime_error(
+            "Input tensor '" + metadata.name + "' data size (" +
+            std::to_string(tensorInput.data.size()) +
+            " bytes) does not match expected size (" +
+            std::to_string(metadata.staticByteCount) + " bytes)");
+      }
     }
-    
-    // Validate input tensor size
-    if (tensorInput.data.size() % tensorSize != 0) {
-      throw std::runtime_error("Input tensor '" + metadata.name + 
-                              "' does not contain whole number of batches");
-    }
-    
-    // Set input shape with batch dimension
-    nvinfer1::Dims inputDims = dims;
-    inputDims.d[0] = batchSize;
-    bool shapeStatus = mContext->setInputShape(metadata.name.c_str(), inputDims);
+
+    bool shapeStatus = mContext->setInputShape(metadata.name.c_str(), actualShape);
     if (!shapeStatus) {
       throw std::runtime_error("Failed to set input shape for tensor: " + metadata.name);
     }
-    
-    // Copy input data to GPU buffer
-    checkCudaErrorCode(cudaMemcpyAsync(mBuffers[i], tensorInput.data.data(), 
-                                      tensorInput.data.size(),
-                                      cudaMemcpyHostToDevice, mInferenceCudaStream));
+
+    checkCudaErrorCode(cudaMemcpyAsync(mBuffers[i], tensorInput.data.data(),
+                                       tensorInput.data.size(),
+                                       cudaMemcpyHostToDevice, mInferenceCudaStream));
   }
 
   // No pre-enqueue sync needed: CUDA stream ordering guarantees H2D copies
@@ -367,44 +376,39 @@ rust::Vec<OutputTensor> Engine::infer(const rust::Vec<InputTensor> &input) {
     throw std::runtime_error("Inference execution failed");
   }
   
-  // Collect output tensors
+  // Collect output tensors using dynamically-inferred shapes
   rust::Vec<OutputTensor> outputs;
-  
+
   for (int i = 0; i < static_cast<int>(mTensorMetadata.size()); ++i) {
     const auto &metadata = mTensorMetadata[i];
-    
+
     if (metadata.ioMode != TensorIOMode::kOUTPUT) {
-      continue; // skip if not tensor output
+      continue;
     }
-    
-    // Find the output length for this tensor
-    size_t outputIdx = 0; // Need to map from tensor index to output index
-    for (int j = 0; j < i; ++j) {
-      if (mTensorMetadata[j].ioMode == TensorIOMode::kOUTPUT) {
-        outputIdx++;
-      }
+
+    // Query the actual output shape from TensorRT (reflects current input shapes)
+    nvinfer1::Dims outputShape = mContext->getTensorShape(metadata.name.c_str());
+
+    size_t copySize = metadata.dataTypeSize;
+    for (int d = 0; d < outputShape.nbDims; ++d) {
+      copySize *= outputShape.d[d];
     }
-    
-    const auto outputLen = batchSize * mOutputLengths[outputIdx];
-    
-    // Create output tensor with bulk-allocated buffer.
+
     OutputTensor output;
-    size_t copySize = outputLen * metadata.dataTypeSize;
     output.name = metadata.name;
     output.dtype = toTensorDataType(metadata.dataType);
     output.data = new_output_buffer(copySize);
-    
-    // Copy data from GPU buffer
-    checkCudaErrorCode(cudaMemcpyAsync(output.data.data(), 
-                                      static_cast<char*>(mBuffers[i]),
-                                      copySize, 
-                                      cudaMemcpyDeviceToHost, mInferenceCudaStream));
-    
+
+    checkCudaErrorCode(cudaMemcpyAsync(output.data.data(),
+                                       static_cast<char *>(mBuffers[i]),
+                                       copySize,
+                                       cudaMemcpyDeviceToHost, mInferenceCudaStream));
+
     outputs.push_back(std::move(output));
   }
-  
+
   checkCudaErrorCode(cudaStreamSynchronize(mInferenceCudaStream));
-  
+
   return outputs;
 }
 
@@ -460,6 +464,34 @@ rust::Vec<TensorInfo> Engine::get_output_dims() const {
       info.dtype = toTensorDataType(metadata.dataType);
       result.push_back(std::move(info));
     }
+  }
+  return result;
+}
+
+rust::Vec<InputShapeProfile> Engine::_get_input_shape_profiles() const {
+  rust::Vec<InputShapeProfile> result;
+  for (const auto &metadata : mTensorMetadata) {
+    if (metadata.ioMode != TensorIOMode::kINPUT) continue;
+
+    InputShapeProfile profile;
+    profile.name = metadata.name;
+    profile.has_dynamic_shape = metadata.hasDynamicShape;
+
+    resize(profile.min_shape, 0);
+    resize(profile.opt_shape, 0);
+    resize(profile.max_shape, 0);
+
+    for (int j = 0; j < metadata.minShape.nbDims; ++j) {
+      profile.min_shape.push_back(static_cast<int32_t>(metadata.minShape.d[j]));
+    }
+    for (int j = 0; j < metadata.optShape.nbDims; ++j) {
+      profile.opt_shape.push_back(static_cast<int32_t>(metadata.optShape.d[j]));
+    }
+    for (int j = 0; j < metadata.maxShape.nbDims; ++j) {
+      profile.max_shape.push_back(static_cast<int32_t>(metadata.maxShape.d[j]));
+    }
+
+    result.push_back(std::move(profile));
   }
   return result;
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -15,6 +15,7 @@ struct Options;
 struct TensorInfo;
 struct InputTensor;
 struct OutputTensor;
+struct InputShapeProfile;
 enum class TensorDataType : uint8_t;
 
 class Logger : public nvinfer1::ILogger {
@@ -80,18 +81,10 @@ public:
   // Get dimensions for all input tensors
   rust::Vec<TensorInfo> get_input_dims() const;
 
-  rust::Vec<uint32_t> _get_batch_dims() const {
-    rust::Vec<uint32_t> rv;
-    rv.push_back(mMinBatchSize);
-    rv.push_back(mOptBatchSize);
-    rv.push_back(mMaxBatchSize);
-    return rv;
-  }
+  rust::Vec<InputShapeProfile> _get_input_shape_profiles() const;
 
   // Get dimensions for all output tensors
   rust::Vec<TensorInfo> get_output_dims() const;
-
-  uint32_t get_output_len() const { return mOutputLengths.empty() ? 0 : mOutputLengths[0]; }
 
   // New methods for multi-tensor support
   size_t get_num_inputs() const;
@@ -105,19 +98,22 @@ private:
     nvinfer1::TensorIOMode ioMode;
     nvinfer1::DataType dataType;
     size_t dataTypeSize;
-    nvinfer1::Dims dims;
+    nvinfer1::Dims dims;              // Engine shape (may have -1 for dynamic)
+    // Per-input profile shapes (INPUT tensors only)
+    nvinfer1::Dims minShape;
+    nvinfer1::Dims optShape;
+    nvinfer1::Dims maxShape;
+    bool hasDynamicShape = false;     // Any dim == -1?
+    int dynamicDimIndex = -1;         // Which dim is dynamic (-1 if none)
+    size_t staticByteCount = 0;       // Product of all static dims * dataTypeSize
   };
 
   // Holds pointers to the input and output GPU buffers
   std::vector<void *> mBuffers;
-  std::vector<uint32_t> mOutputLengths{};
   std::vector<nvinfer1::Dims> mInputDims;
   std::vector<nvinfer1::Dims> mOutputDims;
   std::vector<std::string> mIOTensorNames;
   std::vector<TensorMetadata> mTensorMetadata; // Cached tensor metadata
-  int32_t mMinBatchSize;
-  int32_t mOptBatchSize;
-  int32_t mMaxBatchSize;
 
   // Must keep IRuntime around for inference, see:
   // https://forums.developer.nvidia.com/t/is-it-safe-to-deallocate-nvinfer1-iruntime-after-creating-an-nvinfer1-icudaengine-but-before-running-inference-with-said-icudaengine/255381/2?u=cyruspk4w6

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,16 +241,18 @@ impl Engine {
     /// or (1, 1, 1) if no inputs are dynamic.
     pub fn get_batch_dims(&self) -> BatchDims {
         let profiles = self._get_input_shape_profiles();
-        for p in &profiles {
-            if p.has_dynamic_shape {
-                return BatchDims {
-                    min: p.min_shape[0] as u32,
-                    opt: p.opt_shape[0] as u32,
-                    max: p.max_shape[0] as u32,
-                };
-            }
+        // Prefer the first dynamic input's d[0], but fall back to the first
+        // input's d[0] for fully-static engines (where min == opt == max).
+        let first_dynamic = profiles.iter().find(|p| p.has_dynamic_shape);
+        let p = first_dynamic.or_else(|| profiles.first());
+        match p {
+            Some(p) => BatchDims {
+                min: p.min_shape[0] as u32,
+                opt: p.opt_shape[0] as u32,
+                max: p.max_shape[0] as u32,
+            },
+            None => BatchDims { min: 1, opt: 1, max: 1 },
         }
-        BatchDims { min: 1, opt: 1, max: 1 }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,16 @@ pub mod ffi {
     }
 
     #[derive(Debug, Clone)]
+    /// Per-input shape profile from TensorRT optimization profile.
+    struct InputShapeProfile {
+        name: String,
+        has_dynamic_shape: bool,
+        min_shape: Vec<i32>,
+        opt_shape: Vec<i32>,
+        max_shape: Vec<i32>,
+    }
+
+    #[derive(Debug, Clone)]
     /// Options for creating the inference engine.
     struct Options {
         /// Full path to the TensorRT engine file to load.
@@ -120,9 +130,9 @@ pub mod ffi {
         /// A vector of TensorInfo containing name and dimensions for each input tensor.
         fn get_input_dims(self: &Engine) -> Vec<TensorInfo>;
 
-        /// Return the minimum, optimized, and maximum batch dimension for this engine.
-        /// This is an internal function used by `get_batch_dims`.
-        fn _get_batch_dims(self: &Engine) -> Vec<u32>;
+        /// Return per-input shape profiles (min/opt/max) from the TensorRT optimization profile.
+        /// This is an internal function used by `get_input_shape_profiles`.
+        fn _get_input_shape_profiles(self: &Engine) -> Vec<InputShapeProfile>;
 
         /// Return output dimensions of all output tensors, not including batch dimension.
         ///
@@ -130,37 +140,25 @@ pub mod ffi {
         /// A vector of TensorInfo containing name and dimensions for each output tensor.
         fn get_output_dims(self: &Engine) -> Vec<TensorInfo>;
 
-        /// Return the expected length of the output feature vector.
-        ///
-        /// # Returns
-        /// The total number of elements in the output tensor, equivalent to
-        /// multiplying all elements of `get_output_dims`.
-        fn get_output_len(self: &Engine) -> u32;
-
         /// Get the number of input tensors.
         fn get_num_inputs(self: &Engine) -> usize;
 
         /// Get the number of output tensors.
         fn get_num_outputs(self: &Engine) -> usize;
 
-        /// Run inference on an input batch.
+        /// Run inference on the provided input tensors.
         ///
         /// # Arguments
-        /// * `input` - A flattened vector representing the input tensor data
+        /// * `input` - Named input tensors with flattened data bytes
         ///
         /// # Returns
-        /// A Result containing either the output tensor data as a vector of f32 values,
-        /// or an error message if inference failed.
+        /// A Result containing the output tensors or an error message.
         ///
         /// # Details
-        /// The input batch dimension is dependent on whether the engine has been built with fixed
-        /// or dynamic input batch sizes. If fixed, the input batch dimensions
-        /// must match the value returned by `get_input_dims`. Dynamic may accept any input batch size
-        /// within the range specified by `get_batch_dims`.
-        ///
-        /// The input vector must be a flattened representation of shape
-        /// `get_input_dims` with appropriate batch dimension. Likewise, the output dimension will
-        /// be of shape `get_output_dims` with batch dimension equal to input batch dimension.
+        /// Each input tensor's batch size is resolved independently from its data size.
+        /// For dynamic inputs, the batch dimension must fall within the range specified
+        /// by `get_input_shape_profiles`. For static inputs, the data size must match
+        /// the fixed shape exactly. Different inputs may have different batch sizes.
         fn infer(self: Pin<&mut Engine>, input: &Vec<InputTensor>) -> Result<Vec<OutputTensor>>;
     }
 }
@@ -173,11 +171,14 @@ pub use crate::ffi::{
     TensorInfo,
     InputTensor,
     OutputTensor,
+    InputShapeProfile,
 };
 
 use cxx::{Exception, UniquePtr};
 
-/// Represents the batch dimensions supported by a TensorRT engine
+/// Represents the batch dimensions supported by a TensorRT engine.
+///
+/// Deprecated: Use `get_input_shape_profiles()` for per-input profiles.
 #[derive(Debug, Clone)]
 pub struct BatchDims {
     /// Minimum supported batch size
@@ -186,6 +187,21 @@ pub struct BatchDims {
     pub opt: u32,
     /// Maximum supported batch size
     pub max: u32,
+}
+
+/// Per-input shape profile from a TensorRT optimization profile.
+#[derive(Debug, Clone)]
+pub struct ShapeProfile {
+    /// Name of the input tensor
+    pub name: String,
+    /// Whether this input has any dynamic dimensions
+    pub has_dynamic_shape: bool,
+    /// Minimum shape (full dims including batch) from the optimization profile
+    pub min_shape: Vec<i32>,
+    /// Optimal shape (full dims including batch) from the optimization profile
+    pub opt_shape: Vec<i32>,
+    /// Maximum shape (full dims including batch) from the optimization profile
+    pub max_shape: Vec<i32>,
 }
 
 impl Engine {
@@ -200,22 +216,41 @@ impl Engine {
         crate::ffi::load_engine(&options)
     }
 
+    /// Get shape profiles for all input tensors.
+    ///
+    /// Each input tensor has its own min/opt/max shape from the TensorRT
+    /// optimization profile. For static inputs, min == opt == max.
+    /// For dynamic inputs, the shapes represent the valid range.
+    pub fn get_input_shape_profiles(&self) -> Vec<ShapeProfile> {
+        self._get_input_shape_profiles()
+            .into_iter()
+            .map(|p| ShapeProfile {
+                name: p.name,
+                has_dynamic_shape: p.has_dynamic_shape,
+                min_shape: p.min_shape,
+                opt_shape: p.opt_shape,
+                max_shape: p.max_shape,
+            })
+            .collect()
+    }
+
     /// Get the batch dimension constraints for this engine.
     ///
-    /// # Returns
-    /// A `BatchDims` struct containing the minimum, optimal, and maximum
-    /// batch sizes supported by this engine.
-    ///
-    /// For fixed-batch engines, all values will typically be the same.
-    /// For dynamic-batch engines, these values represent the valid range
-    /// of batch sizes that can be used.
-    pub fn get_batch_dims(self: &Engine) -> BatchDims {
-        let vs = self._get_batch_dims();
-        BatchDims {
-            min: vs[0],
-            opt: vs[1],
-            max: vs[2],
+    /// Deprecated: Use `get_input_shape_profiles()` for per-input profiles.
+    /// This returns the profile of the first dynamic input's first dimension,
+    /// or (1, 1, 1) if no inputs are dynamic.
+    pub fn get_batch_dims(&self) -> BatchDims {
+        let profiles = self._get_input_shape_profiles();
+        for p in &profiles {
+            if p.has_dynamic_shape {
+                return BatchDims {
+                    min: p.min_shape[0] as u32,
+                    opt: p.opt_shape[0] as u32,
+                    max: p.max_shape[0] as u32,
+                };
+            }
         }
+        BatchDims { min: 1, opt: 1, max: 1 }
     }
 }
 


### PR DESCRIPTION
Adds per-input heterogeneous dynamic shape support; each input tensor now has its own min/opt/max shape profile from TensorRT, replacing the single global batch size.  Input buffers allocated per their own max shape; output buffers sized via TensorRT shape propagation after setting all inputs to max. `infer()` resolves each input's dynamic dimension independently using precomputed metadata (one integer division per dynamic input, zero heap allocations).

Also removed `get_output_len()` and `mOutputLengths`, output sizes now queried dynamically from `mContext->getTensorShape()` after input shapes are set

Questions: 
- remove `get_batch_dims()`?

## Benchmarks:
####  FP16 engine (3 tensors, 1 dynamic dim on [1])

| dynD | Avg | p50 | p99 | Throughput |
|-------|-----|-----|-----|------------|
| 1 | 5.57ms | 5.57ms | 5.65ms | 179.6 infer/s |
| 16 | 11.47ms | 11.48ms | 11.76ms | 87.2 infer/s |
| 64 | 38.96ms | 39.07ms | 39.67ms | 25.7 infer/s |

#### FP32 engine (3 tensors, 1 dynamic dim on [1])

| dynD | Avg | p50 | p99 | Throughput |
|-------|-----|-----|-----|------------|
| 1 | 20.00ms | 20.00ms | 20.18ms | 50.0 infer/s |
| 16 | 37.37ms | 37.23ms | 39.86ms | 26.8 infer/s |
| 64 | 127.2ms | — | — | ~7.9 infer/s |

#### YOLOv8n (static, single input)

| Metric | Value |
|--------|-------|
| Avg | 1.750ms |
| p50 | 1.763ms |
| p99 | 1.781ms |
| Min | 1.642ms |
| Max | 1.787ms |
| Throughput | 571.5 infer/s |