### PR TITLE
chore: use global logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libinfer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -261,6 +261,7 @@ dependencies = [
  "cudarc",
  "cxx",
  "cxx-build",
+ "libc",
  "pkg-config",
  "rand",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libinfer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust interface to TensorRT for high-performance GPU inference"
 authors = ["Saronic Technologies"]
@@ -34,6 +34,7 @@ approx = "0.5.1"
 clap = { version = "4.5.27", features = ["derive"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+libc = "0.2"
 rand = "0.8.5"
 
 [package.metadata.docs.rs]

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,7 @@
           tensorrt
           rustc
           cargo
+          clippy
           rustfmt
           spdlog
           fmt

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -10,6 +10,11 @@
 
 using namespace nvinfer1;
 
+static Logger &getGlobalLogger() {
+  static Logger instance;
+  return instance;
+}
+
 static size_t getDataTypeSize(DataType dt) {
   switch (dt) {
   case DataType::kFLOAT:
@@ -108,7 +113,7 @@ void Engine::load() {
     throw std::runtime_error("Unable to read engine file");
   }
 
-  mRuntime = std::unique_ptr<IRuntime>{createInferRuntime(mLogger)};
+  mRuntime = std::unique_ptr<IRuntime>{createInferRuntime(getGlobalLogger())};
   if (!mRuntime) {
     throw std::runtime_error("Runtime not initialized");
   }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,6 +33,43 @@ fn bytes_to_f32(v: &[u8]) -> Vec<f32> {
         .collect()
 }
 
+// --- Shared logger ---
+
+#[test]
+fn test_multiple_engines_no_duplicate_logger_warning() {
+    use std::io::Read;
+    use std::os::unix::io::FromRawFd;
+
+    let mut fds = [0i32; 2];
+    assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+    let read_fd = fds[0];
+    let write_fd = fds[1];
+
+    let old_stderr = unsafe { libc::dup(2) };
+    assert!(old_stderr >= 0);
+    assert_eq!(unsafe { libc::dup2(write_fd, 2) }, 2);
+
+    let ctx = cuda_ctx();
+    let _engine1 = load_engine("test_dynamic.engine", &ctx);
+    let _engine2 = load_engine("test_multi_input.engine", &ctx);
+    let _engine3 = load_engine("test_dynamic.engine", &ctx);
+
+    assert_eq!(unsafe { libc::dup2(old_stderr, 2) }, 2);
+    unsafe {
+        libc::close(old_stderr);
+        libc::close(write_fd);
+    }
+
+    let mut captured = String::new();
+    let mut reader = unsafe { std::fs::File::from_raw_fd(read_fd) };
+    reader.read_to_string(&mut captured).ok();
+
+    assert!(
+        !captured.contains("logger passed into createInferRuntime differs"),
+        "duplicate logger warning detected in stderr:\n{captured}"
+    );
+}
+
 // --- Error handling ---
 
 #[test]


### PR DESCRIPTION
Use a global logger to avoid warning spam from TRT that a logger has already been initialized.