### PR TITLE
feat: add memory breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libinfer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libinfer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust interface to TensorRT for high-performance GPU inference"
 authors = ["Saronic Technologies"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,8 +11,8 @@ use cudarc::driver::{CudaContext, DevicePtr, DevicePtrMut};
 use libinfer::{Engine, Options};
 use std::path::PathBuf;
 use std::process;
-use tracing::{error, info, Level};
 use tracing::subscriber::set_global_default;
+use tracing::{error, info, Level};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[derive(Parser, Debug)]

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -11,8 +11,8 @@ use libinfer::{Engine, Options};
 use std::path::PathBuf;
 use std::process;
 use std::time::{Duration, Instant};
-use tracing::{error, info, Level};
 use tracing::subscriber::set_global_default;
+use tracing::{error, info, Level};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[derive(Parser, Debug)]

--- a/examples/dynamic.rs
+++ b/examples/dynamic.rs
@@ -11,8 +11,8 @@ use libinfer::{Engine, Options};
 use std::path::PathBuf;
 use std::process;
 use std::time::Instant;
-use tracing::{error, info, warn, Level};
 use tracing::subscriber::set_global_default;
+use tracing::{error, info, warn, Level};
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 #[derive(Parser, Debug)]

--- a/flake.lock
+++ b/flake.lock
@@ -25,6 +25,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -40,6 +56,27 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -94,11 +131,34 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775585728,
+        "narHash": "sha256-8Psjt+TWvE4thRKktJsXfR6PA/fWWsZ04DVaY6PUhr4=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "580633fa3fe5fc0379905986543fd7495481913d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "jetpack-nixos": "jetpack-nixos",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,12 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
     jetpack-nixos.url = "github:anduril/jetpack-nixos";
+    pre-commit-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
-  outputs = { nixpkgs, flake-utils, jetpack-nixos, ... }:
+  outputs = { nixpkgs, flake-utils, jetpack-nixos, pre-commit-hooks, ... }:
     let
       supported-systems = with flake-utils.lib.system; [
         x86_64-linux
@@ -37,6 +41,7 @@
           nixpkgs-fmt
           openssl
           pkg-config
+          pre-commit
           cudatoolkit
           tensorrt
           rustc
@@ -67,6 +72,25 @@
         includes = pkgs.lib.makeSearchPath "include" [
           pkgs.glibc.dev
         ];
+
+        pre-commit-checks = pre-commit-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            clippy = {
+              name = "clippy";
+              enable = true;
+              entry = "cargo clippy --all-targets";
+              types = [ "rust" ];
+              pass_filenames = false;
+              language = "system";
+            };
+            rustfmt.enable = true;
+            clang-format = {
+              enable = true;
+              types_or = [ "c" "c++" ];
+            };
+          };
+        };
       in
       {
         devShells = {
@@ -83,6 +107,7 @@
             shellHook = ''
               export CC="clang"
               export CXX="clang++"
+              ${pre-commit-checks.shellHook}
             '';
 
           };

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -88,8 +88,7 @@ static void init_logger() {
   }
 }
 
-Engine::Engine(const Options &options)
-    : kEnginePath(options.path) {
+Engine::Engine(const Options &options) : kEnginePath(options.path) {
   static std::once_flag logger_init;
   std::call_once(logger_init, init_logger);
 }
@@ -126,8 +125,8 @@ void Engine::load() {
     throw std::runtime_error("Engine deserialization failed");
   }
 
-  mContext = std::unique_ptr<IExecutionContext>(
-      mEngine->createExecutionContext());
+  mContext =
+      std::unique_ptr<IExecutionContext>(mEngine->createExecutionContext());
   if (!mContext) {
     throw std::runtime_error("Could not create execution context");
   }
@@ -152,11 +151,14 @@ void Engine::load() {
 
     if (tensorType == TensorIOMode::kINPUT) {
       int32_t minBatch =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMIN).d[0];
+          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMIN)
+              .d[0];
       int32_t optBatch =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kOPT).d[0];
+          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kOPT)
+              .d[0];
       int32_t maxBatch =
-          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMAX).d[0];
+          mEngine->getProfileShape(tensorName, 0, OptProfileSelector::kMAX)
+              .d[0];
 
       if (mMinBatchSize == 0) {
         mMinBatchSize = minBatch;
@@ -200,14 +202,14 @@ void Engine::enqueue(const uint64_t *input_ptrs, size_t num_inputs,
   }
 
   if (num_inputs != get_num_inputs()) {
-    throw std::runtime_error(
-        "Expected " + std::to_string(get_num_inputs()) +
-        " input pointers, got " + std::to_string(num_inputs));
+    throw std::runtime_error("Expected " + std::to_string(get_num_inputs()) +
+                             " input pointers, got " +
+                             std::to_string(num_inputs));
   }
   if (num_outputs != get_num_outputs()) {
-    throw std::runtime_error(
-        "Expected " + std::to_string(get_num_outputs()) +
-        " output pointers, got " + std::to_string(num_outputs));
+    throw std::runtime_error("Expected " + std::to_string(get_num_outputs()) +
+                             " output pointers, got " +
+                             std::to_string(num_outputs));
   }
 
   size_t inputIdx = 0;
@@ -223,15 +225,17 @@ void Engine::enqueue(const uint64_t *input_ptrs, size_t num_inputs,
         throw std::runtime_error("Failed to set input shape for tensor: " +
                                  meta.name);
       }
-      if (!mContext->setTensorAddress(meta.name.c_str(),
-                                      reinterpret_cast<void *>(input_ptrs[inputIdx]))) {
+      if (!mContext->setTensorAddress(
+              meta.name.c_str(),
+              reinterpret_cast<void *>(input_ptrs[inputIdx]))) {
         throw std::runtime_error("Unable to set tensor address for: " +
                                  meta.name);
       }
       inputIdx++;
     } else {
-      if (!mContext->setTensorAddress(meta.name.c_str(),
-                                      reinterpret_cast<void *>(output_ptrs[outputIdx]))) {
+      if (!mContext->setTensorAddress(
+              meta.name.c_str(),
+              reinterpret_cast<void *>(output_ptrs[outputIdx]))) {
         throw std::runtime_error("Unable to set tensor address for: " +
                                  meta.name);
       }
@@ -329,4 +333,13 @@ size_t Engine::get_num_outputs() const {
     }
   }
   return count;
+}
+
+EngineMemory Engine::get_memory_breakdown() const {
+  return EngineMemory{
+      static_cast<uint64_t>(mEngine->getDeviceMemorySizeV2()),
+      static_cast<uint64_t>(mEngine->getStreamableWeightsSize()),
+      static_cast<uint64_t>(mEngine->getWeightStreamingBudgetV2()),
+      static_cast<uint64_t>(mEngine->getWeightStreamingScratchMemorySize()),
+  };
 }

--- a/src/engine.h
+++ b/src/engine.h
@@ -11,6 +11,7 @@
 
 #include "rust/cxx.h"
 
+struct EngineMemory;
 struct Options;
 struct TensorInfo;
 enum class TensorDataType : uint8_t;
@@ -72,8 +73,8 @@ public:
   // Enqueue inference with caller-provided device pointers and stream.
   // Synchronizes the stream before returning.
   void infer(const uint64_t *input_ptrs, size_t num_inputs,
-             const uint64_t *output_ptrs, size_t num_outputs,
-             uint64_t stream, uint32_t batch_size);
+             const uint64_t *output_ptrs, size_t num_outputs, uint64_t stream,
+             uint32_t batch_size);
 
   // Same as infer() but does not synchronize. Caller is responsible.
   void infer_async(const uint64_t *input_ptrs, size_t num_inputs,
@@ -86,6 +87,7 @@ public:
   uint32_t get_output_len() const;
   size_t get_num_inputs() const;
   size_t get_num_outputs() const;
+  EngineMemory get_memory_breakdown() const;
 
 private:
   struct TensorMetadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,33 @@ mod ffi {
         path: String,
     }
 
+    /// Per-engine device memory breakdown.
+    ///
+    /// Covers memory the TensorRT runtime tracks explicitly for a single
+    /// engine and execution context on the default optimization profile.
+    /// Does not include weight allocations the runtime makes outside the
+    /// streaming accounting, CUDA context overhead, or memory held by
+    /// other subsystems such as cv-cuda or NVENC. Use a driver-level
+    /// query for the full device total.
+    #[derive(Debug, Clone, Copy)]
+    struct EngineMemory {
+        /// Activation and scratch buffer bytes required per execution
+        /// context.
+        activation_scratch: u64,
+
+        /// Weight bytes marked streamable at engine build time. Zero
+        /// unless weight streaming was enabled during build.
+        streamable_weights: u64,
+
+        /// Weight bytes currently budgeted to reside on the device.
+        /// Equals `streamable_weights` when streaming is disabled.
+        resident_weights: u64,
+
+        /// Additional per-execution-context scratch required while
+        /// weight streaming is active. Zero when streaming is disabled.
+        streaming_scratch: u64,
+    }
+
     unsafe extern "C++" {
         include!("libinfer/src/engine.h");
 
@@ -41,6 +68,7 @@ mod ffi {
         fn get_output_len(self: &Engine) -> u32;
         fn get_num_inputs(self: &Engine) -> usize;
         fn get_num_outputs(self: &Engine) -> usize;
+        fn get_memory_breakdown(self: &Engine) -> EngineMemory;
 
         /// # Safety
         ///
@@ -72,7 +100,7 @@ mod ffi {
     }
 }
 
-pub use ffi::{Options, TensorDataType, TensorInfo};
+pub use ffi::{EngineMemory, Options, TensorDataType, TensorInfo};
 
 impl TensorDataType {
     /// Size in bytes of a single element of this type.
@@ -199,6 +227,11 @@ impl Engine {
     /// Output length (elements) of the first output tensor.
     pub fn get_output_len(&self) -> u32 {
         self.inner.get_output_len()
+    }
+
+    /// Device memory breakdown for this engine.
+    pub fn memory(&self) -> EngineMemory {
+        self.inner.get_memory_breakdown()
     }
 }
 


### PR DESCRIPTION
Adds a `memory()` function which returns an `EngineMemory` breakdown of memory usage, at least as much as the TensorRT API actually shows. There are some caveats since this isn't the true total story of how much memory an engine will take. For that, driver level APIs should be referenced. This breakdown is at least useful at a high level for understanding memory allocations, however.