### PR TITLE
fix: logspam for non-streaming weights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libinfer"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libinfer"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Rust interface to TensorRT for high-performance GPU inference"
 authors = ["Saronic Technologies"]

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -336,10 +336,25 @@ size_t Engine::get_num_outputs() const {
 }
 
 EngineMemory Engine::get_memory_breakdown() const {
+  // getStreamableWeightsSize returns 0 for engines not built with
+  // BuilderFlag::kWEIGHT_STREAMING. Calling the V2 budget or scratch queries
+  // on such an engine logs a TRT API-usage error. Skip them when streaming
+  // is disabled.
+  uint64_t streamable =
+      static_cast<uint64_t>(mEngine->getStreamableWeightsSize());
+  uint64_t resident_weights = 0;
+  uint64_t streaming_scratch = 0;
+  if (streamable > 0) {
+    resident_weights =
+        static_cast<uint64_t>(mEngine->getWeightStreamingBudgetV2());
+    streaming_scratch =
+        static_cast<uint64_t>(mEngine->getWeightStreamingScratchMemorySize());
+  }
+
   return EngineMemory{
       static_cast<uint64_t>(mEngine->getDeviceMemorySizeV2()),
-      static_cast<uint64_t>(mEngine->getStreamableWeightsSize()),
-      static_cast<uint64_t>(mEngine->getWeightStreamingBudgetV2()),
-      static_cast<uint64_t>(mEngine->getWeightStreamingScratchMemorySize()),
+      streamable,
+      resident_weights,
+      streaming_scratch,
   };
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -193,6 +193,15 @@ fn test_dynamic_batch_dims() {
     assert_eq!(outputs[0].dtype, TensorDataType::FP32);
     assert_eq!(outputs[0].byte_size(), 2 * 4);
     assert_eq!(engine.get_output_len(), 2);
+
+    let mem = engine.memory();
+    println!(
+        "test_dynamic.engine memory: activation_scratch={} streamable_weights={} resident_weights={} streaming_scratch={}",
+        mem.activation_scratch,
+        mem.streamable_weights,
+        mem.resident_weights,
+        mem.streaming_scratch,
+    );
 }
 
 #[test]
@@ -278,6 +287,15 @@ fn test_multi_input_metadata() {
     assert_eq!(batch.min, 1);
     assert_eq!(batch.opt, 4);
     assert_eq!(batch.max, 8);
+
+    let mem = engine.memory();
+    println!(
+        "test_multi_input.engine memory: activation_scratch={} streamable_weights={} resident_weights={} streaming_scratch={}",
+        mem.activation_scratch,
+        mem.streamable_weights,
+        mem.resident_weights,
+        mem.streaming_scratch,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Removes a logline that is generated when memory usage is queried on an engine not built for weight streaming.

```
[2026-04-20 13:03:50.314] [libinfer] [error] ICudaEngine::getWeightStreamingBudgetV2: Error Code 3: API Usage Error (Parameter check failed, condition: mEnableWeightStreaming. This engine was not built with weight streaming support. This engine must be rebuilt by setting BuilderFlag::kWEIGHT_STREAMING during build time. In getWeightStreamingBudgetV2 at /_src/runtime/api/engine.cpp:2464)